### PR TITLE
Preparation for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+script: ./gradlew clean build
+
+jdk:
+  - oraclejdk7
+  - openjdk7
+  - openjdk6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Asciidoctor Gradle Plugin
 -------------------------
 
+![Travis Build Status](https://travis-ci.org/asciidoctor/asciidoctor-gradle-plugin.png?branch=master["Build Status", link="https://travis-ci.org/asciidoctor/asciidoctor-gradle-plugin"])
+
 This is a port of the [asciidoctor-maven-plugin][1] project by [@LightGuard][2]. Currently supports **html5** backend only.
 
 Installation


### PR DESCRIPTION
Can you set up the CI job on Travis similar to the Maven plugin? This pull request already has the required setup.
