### PR TITLE
Makes AsciidoctorWorker Serializable

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -31,7 +31,7 @@ class AsciidoctorTask extends DefaultTask {
     @Input File sourceDir
     @OutputDirectory File outputDir
     @Input String backend
-    @Input AsciidoctorWorker worker
+    AsciidoctorWorker worker
 
     AsciidoctorTask() {
         sourceDir = project.file('src/asciidoc')


### PR DESCRIPTION
Without this, Gradle was throwing an internal error about not being able
to serialize it.
