### PR TITLE
Make up-to-date detection work for AsciidoctorTask

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
@@ -28,7 +29,7 @@ import org.gradle.api.tasks.TaskAction
  * @author Andres Almiray
  */
 class AsciidoctorTask extends DefaultTask {
-    @Input File sourceDir
+    @InputDirectory File sourceDir
     @OutputDirectory File outputDir
     @Input String backend
     AsciidoctorWorker worker


### PR DESCRIPTION
After it's been run once, Gradle considers AsciidoctorTask to be
up-to-date even if a file beneath sourceDir has been changed. Update
sourceDir so that it is annotated @InputDirectory rather than @Input
so that all of the files beneath sourceDir are considered when Gradle
is determining whether or not the task is up-to-date.
