### PR TITLE
Add a 'logDocuments' configuration option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -39,7 +39,7 @@ apply plugin: 'asciidoctor'
 
 == Usage
 
-The plugin adds a new task named `asciidoctor`. This task exposes 5 properties as part of its configuration
+The plugin adds a new task named `asciidoctor`. This task exposes 6 properties as part of its configuration
 
 [horizontal]
 sourceDir:: where the asciidoc sources are. Type: File. Default: `src/asciidoc`.
@@ -47,7 +47,8 @@ sourceDocumentName:: an override to process a single source file. Type: File. De
 outputDir:: where generated docs go. Type: File. Default: `$buildDir/asciidoc`.
 backend:: the backend to use. Type: String. Default: `html5`.
 options:: a Map specifying different options that can be sent to Asciidoctor.
- 
+logDocuments:: a boolean specifying if documents being processed should be logged on console. Type: boolean. Default: `false`
+
 Sources may have any of the following extensions in order to be discovered
 
  * .asciidoc

--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -40,6 +40,7 @@ class AsciidoctorTask extends DefaultTask {
     @OutputDirectory File outputDir
     @Input String backend
     @Input Map options = [:]
+    @Optional boolean logDocuments = false
 
     Asciidoctor asciidoctor
 
@@ -92,6 +93,9 @@ class AsciidoctorTask extends DefaultTask {
     private void processSingleDocument() {
         try {
             if (sourceDocumentName.name =~ ASCIIDOC_FILE_EXTENSION_PATTERN) {
+                if (getLogDocuments()) {
+                    logger.lifecycle("Rendering $sourceDocumentName")
+                }
                 asciidoctor.renderFile(sourceDocumentName, mergedOptions(options, outputDir, backend))
             }
         } catch (Exception e) {
@@ -108,6 +112,9 @@ class AsciidoctorTask extends DefaultTask {
                 } else {
                     File destinationParentDir = outputDirFor(file, sourceDir.absolutePath, outputDir)
                     if (file.name =~ ASCIIDOC_FILE_EXTENSION_PATTERN) {
+                        if (getLogDocuments()) {
+                            logger.lifecycle("Rendering $file")
+                        }
                         asciidoctor.renderFile(file, mergedOptions(options, outputDir, backend))
                     } else {
                         File target = new File("${destinationParentDir}/${file.name}")


### PR DESCRIPTION
- false by default
- if true, logs files being processed with "lifecycle" logging level
- closes #21

I chose to use a log option instead of doing `logger.info` because otherwise, you would need to run Gradle with `--info` log level, which adds too much verbosity.
