### PR TITLE
Fix so document directory structure in source is reflected in output.

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -108,7 +108,7 @@ class AsciidoctorTask extends DefaultTask {
                 } else {
                     File destinationParentDir = outputDirFor(file, sourceDir.absolutePath, outputDir)
                     if (file.name =~ ASCIIDOC_FILE_EXTENSION_PATTERN) {
-                        asciidoctor.renderFile(file, mergedOptions(options, outputDir, backend))
+                        asciidoctor.renderFile(file, mergedOptions(options, destinationParentDir, backend))
                     } else {
                         File target = new File("${destinationParentDir}/${file.name}")
                         target.withOutputStream { it << file.newInputStream() }

--- a/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskSpec.groovy
+++ b/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskSpec.groovy
@@ -55,7 +55,7 @@ class AsciidoctorTaskSpec extends Specification {
 
             task.gititdone()
         then:
-            1 * mockAsciidoctor.renderFile(_, _)
+            2 * mockAsciidoctor.renderFile(_, _)
     }
 
     @SuppressWarnings('MethodName')
@@ -90,5 +90,20 @@ class AsciidoctorTaskSpec extends Specification {
             task.gititdone()
         then:
             1 * mockAsciidoctor.renderFile(_, _)
+    }
+
+    def "Source documents in directories end up in the corresponding output directory"() {
+        given:
+            Task task = project.tasks.create(name: ASCIIDOCTOR, type: AsciidoctorTask) {
+                asciidoctor = mockAsciidoctor
+                sourceDir = new File(rootDir, ASCIIDOC_RESOURCES_DIR)
+                outputDir = new File(rootDir, ASCIIDOC_BUILD_DIR)
+            }
+        when:
+            task.gititdone()
+        then:
+            1 * mockAsciidoctor.renderFile(new File(task.sourceDir, 'subdir/sample2.ad'), { it.to_dir == new File(task.outputDir, 'subdir').absolutePath })
+            1 * mockAsciidoctor.renderFile(new File(task.sourceDir, 'sample.asciidoc'), { it.to_dir == task.outputDir.absolutePath })
+            0 * mockAsciidoctor.renderFile(_, _)
     }
 }

--- a/src/test/resources/src/asciidoc/subdir/sample2.ad
+++ b/src/test/resources/src/asciidoc/subdir/sample2.ad
@@ -1,0 +1,26 @@
+Document Title
+==============
+Doc Writer <thedoc@asciidoctor.org>
+:idprefix: id_
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Section A
+
+*Section A* paragraph.
+
+=== Section A Subsection
+
+*Section A* 'subsection' paragraph.
+
+== Section B
+
+*Section B* paragraph.
+
+.Section B list
+* Item 1
+* Item 2
+* Item 3
+


### PR DESCRIPTION
Prior to this, a document under `<srcdir>/mydir/doc.ad` would end up in `<outputdir>/doc.ad` instead of `<outputdir>/mydir/doc.ad`.
