### PR TITLE
resolves #29 recognize all built-in backends, pass through others

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorBackend.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorBackend.groovy
@@ -20,9 +20,10 @@ package org.asciidoctor.gradle
  * Supported backends.
  *
  * @author Benjamin Muschko
+ * @author Dan Allen
  */
 enum AsciidoctorBackend {
-    HTML5('html5'), DOCBOOK('docbook')
+    HTML('html'), DOCBOOK('docbook'), HTML5('html5'), DOCBOOK45('docbook45'), DOCBOOK5('docbook5')
 
     private final static Map<String, AsciidoctorBackend> ALL_BACKENDS
     private final String id
@@ -39,7 +40,7 @@ enum AsciidoctorBackend {
         id
     }
 
-    static boolean isSupported(String name) {
+    static boolean isBuiltIn(String name) {
         ALL_BACKENDS.containsKey(name)
     }
 }

--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -54,8 +54,8 @@ class AsciidoctorTask extends DefaultTask {
      * Validates input values. If an input value is not valid an exception is thrown.
      */
     private void validateInputs() {
-        if (!AsciidoctorBackend.isSupported(backend)) {
-            throw new InvalidUserDataException("Unsupported backend: $backend")
+        if (!AsciidoctorBackend.isBuiltIn(backend)) {
+            logger.lifecycle("Passing through unknown backend: $backend")
         }
     }
 

--- a/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskSpec.groovy
+++ b/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskSpec.groovy
@@ -35,12 +35,16 @@ class AsciidoctorTaskSpec extends Specification {
             project.tasks.findByName(ASCIIDOCTOR) == null
         when:
             Task task = project.tasks.add(name: ASCIIDOCTOR, type: AsciidoctorTask) {
+                asciidoctor = mockAsciidoctor
+                sourceDir = new File(rootDir, ASCIIDOC_RESOURCES_DIR)
+                outputDir = new File(rootDir, ASCIIDOC_BUILD_DIR)
                 backend = 'unknown'
             }
 
             task.gititdone()
         then:
-            thrown(InvalidUserDataException)
+            org.asciidoctor.gradle.AsciidoctorBackend.isBuiltIn('unknown') == false
+            2 * mockAsciidoctor.renderFile(_, _)
     }
 
     @SuppressWarnings('MethodName')


### PR DESCRIPTION
I wasn't sure how to test that the validation produces a lifecycle logger message when the backend is unknown, so instead I added the assertion of the condition that triggers the warning.
