### PR TITLE
resolves #31 support attributes as String, List and Array

### DIFF
--- a/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskSpec.groovy
+++ b/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskSpec.groovy
@@ -108,4 +108,78 @@ class AsciidoctorTaskSpec extends Specification {
             1 * mockAsciidoctor.renderFile(new File(task.sourceDir, ASCIIDOC_SAMPLE_FILE), { it.to_dir == task.outputDir.absolutePath })
             0 * mockAsciidoctor.renderFile(_, _)
     }
+
+    @SuppressWarnings('MethodName')
+    def "Should support String value for attributes option"() {
+        given:
+            Task task = project.tasks.create(name: ASCIIDOCTOR, type: AsciidoctorTask) {
+                asciidoctor = mockAsciidoctor
+                sourceDir = new File(rootDir, ASCIIDOC_RESOURCES_DIR)
+                outputDir = new File(rootDir, ASCIIDOC_BUILD_DIR)
+                sourceDocumentName = new File(rootDir, ASCIIDOC_SAMPLE_FILE)
+                options = [
+                  attributes: 'toc=right source-highlighter=coderay'
+                ]
+            }
+        when:
+            task.gititdone()
+        then:
+            1 * mockAsciidoctor.renderFile(_, _)
+    }
+
+    @SuppressWarnings('MethodName')
+    def "Should support GString value for attributes option"() {
+        given:
+            Task task = project.tasks.create(name: ASCIIDOCTOR, type: AsciidoctorTask) {
+                asciidoctor = mockAsciidoctor
+                sourceDir = new File(rootDir, ASCIIDOC_RESOURCES_DIR)
+                outputDir = new File(rootDir, ASCIIDOC_BUILD_DIR)
+                sourceDocumentName = new File(rootDir, ASCIIDOC_SAMPLE_FILE)
+                def attrs = "toc=right source-highlighter=coderay"
+                options = [
+                  attributes: "$attrs"
+                ]
+            }
+        when:
+            task.gititdone()
+        then:
+            1 * mockAsciidoctor.renderFile(_, _)
+    }
+
+    @SuppressWarnings('MethodName')
+    def "Should support List value for attributes option"() {
+        given:
+            Task task = project.tasks.create(name: ASCIIDOCTOR, type: AsciidoctorTask) {
+                asciidoctor = mockAsciidoctor
+                sourceDir = new File(rootDir, ASCIIDOC_RESOURCES_DIR)
+                outputDir = new File(rootDir, ASCIIDOC_BUILD_DIR)
+                sourceDocumentName = new File(rootDir, ASCIIDOC_SAMPLE_FILE)
+                def highlighter = 'coderay'
+                options = [
+                  attributes: ['toc=right', "source-highlighter=$highlighter"]
+                ]
+            }
+        when:
+            task.gititdone()
+        then:
+            1 * mockAsciidoctor.renderFile(_, _)
+    }
+
+    @SuppressWarnings('MethodName')
+    def "Throws exception when attributes option value is an unsupported type"() {
+        given:
+            Task task = project.tasks.create(name: ASCIIDOCTOR, type: AsciidoctorTask) {
+                asciidoctor = mockAsciidoctor
+                sourceDir = new File(rootDir, ASCIIDOC_RESOURCES_DIR)
+                outputDir = new File(rootDir, ASCIIDOC_BUILD_DIR)
+                sourceDocumentName = new File(rootDir, ASCIIDOC_SAMPLE_FILE)
+                options = [
+                  attributes: 23
+                ]
+            }
+        when:
+            task.gititdone()
+        then:
+            thrown(Exception)
+    }
 }


### PR DESCRIPTION
I implemented all the logic for processing the String-based and List-based attribute declarations. In the future, we could consider delegating this to Asciidoctor Java if it can be done safely. However, due to issues with GString, I'm guessing it's safest done in the plugin, or using a utility method provided by Asciidoctor Java (ideal).

The tests verify that the attributes are processed without exception, but not that they are processed correctly.
