### PR TITLE
resolves #39 process non-AsciiDoc files when sourceDocumentName is set

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -108,6 +108,13 @@ class AsciidoctorTask extends DefaultTask {
                     outputDir: outputDir,
                     backend: backend))
             }
+            sourceDir.eachFileRecurse { File file ->
+                if (file.file && !(file.name =~ ASCIIDOC_FILE_EXTENSION_PATTERN)) {
+                    File destinationParentDir = outputDirFor(file, sourceDir.absolutePath, outputDir)
+                    File target = new File("${destinationParentDir}/${file.name}")
+                    target.withOutputStream { it << file.newInputStream() }
+                }
+            }
         } catch (Exception e) {
             throw new GradleException('Error running Asciidoctor on single source', e)
         }


### PR DESCRIPTION
also includes fix for annotation on baseDir field (should be directory, not file)
