### PR TITLE
resolves #36 skip files and directories that begin with an underscore

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -118,9 +118,7 @@ class AsciidoctorTask extends DefaultTask {
     private void processAllDocuments() {
         try {
             sourceDir.eachFileRecurse { File file ->
-                if (file.directory) {
-                    outputDirFor(file, sourceDir.absolutePath, outputDir)
-                } else {
+                if (file.file && !file.name.startsWith('_')) {
                     File destinationParentDir = outputDirFor(file, sourceDir.absolutePath, outputDir)
                     if (file.name =~ ASCIIDOC_FILE_EXTENSION_PATTERN) {
                         if (logDocuments) {

--- a/src/test/resources/src/asciidoc/subdir/_include.adoc
+++ b/src/test/resources/src/asciidoc/subdir/_include.adoc
@@ -1,0 +1,1 @@
+an include file


### PR DESCRIPTION
Note that this fix also prevents empty folders from being created in the output directory.
