### PR TITLE
set backend as option instead of attribute

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -152,6 +152,7 @@ class AsciidoctorTask extends DefaultTask {
     private static Map<String, Object> mergedOptions(Map params) {
         Map<String, Object> mergedOptions = [:]
         mergedOptions.putAll(params.options)
+        mergedOptions.backend = params.backend
         mergedOptions.in_place = false
         mergedOptions.safe = 0i
         mergedOptions.to_dir = params.outputDir.absolutePath
@@ -203,7 +204,6 @@ class AsciidoctorTask extends DefaultTask {
             }
         }
 
-        attributes.backend = params.backend
         attributes.projectdir = params.projectDir.absolutePath
         attributes.rootdir = params.rootDir.absolutePath
         mergedOptions.attributes = attributes


### PR DESCRIPTION
Asciidoctor sets the attribute internally. The benefit is that the option has higher precedence than the attribute, makes it clear who is doing the setting.
