### PR TITLE
Pass options to fopub backend

### DIFF
--- a/samples/fopub/build.gradle
+++ b/samples/fopub/build.gradle
@@ -22,4 +22,12 @@ asciidoctor {
             copycss: true
         ]
     ]
+    fopub {
+        // xsltFile = new File("src/docbook/custom-fo-pdf.xsl")
+        params = [
+            // See http://docbook.sourceforge.net/release/xsl/1.78.1/doc/param.html
+            'page.orientation': 'landscape',
+            'text.color': '#004080'
+        ]
+    }
 }

--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.*
+import org.gradle.util.ConfigureUtil
 
 /**
  * @author Noam Tenne
@@ -30,6 +31,7 @@ import org.gradle.api.tasks.*
  * @author Dmitri Vyazelenko
  * @author Dan Allen
  * @author Rob Winch
+ * @author Stefan Schlott
  */
 class AsciidoctorTask extends DefaultTask {
     private static final boolean IS_WINDOWS = System.getProperty('os.name').contains('Windows')
@@ -45,6 +47,7 @@ class AsciidoctorTask extends DefaultTask {
     @Input Set<String> backends
     @Input Map options = [:]
     @Optional boolean logDocuments = false
+    FopubOptions fopubOptions = new FopubOptions()
 
     Asciidoctor asciidoctor
     FopubFacade fopub = new FopubFacade()
@@ -58,6 +61,11 @@ class AsciidoctorTask extends DefaultTask {
 
     void setBackend(String backend) {
         this.backends = [backend]
+    }
+
+    FopubOptions fopub(Closure closure) {
+        fopubOptions = ConfigureUtil.configure(closure, fopubOptions);
+        return fopubOptions
     }
 
     /**
@@ -124,7 +132,7 @@ class AsciidoctorTask extends DefaultTask {
 
                         if (isFoPub) {
                             File workingDir = new File("${outputDir}/$backend/work")
-                            fopub.renderPdf(file, workingDir, destinationParentDir)
+                            fopub.renderPdf(file, workingDir, destinationParentDir, fopubOptions)
                         }
                     }
                 } else {

--- a/src/main/groovy/org/asciidoctor/gradle/FopubFacade.java
+++ b/src/main/groovy/org/asciidoctor/gradle/FopubFacade.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.URL;
+import java.util.Map;
 import java.util.Vector;
 
 /**
@@ -47,16 +48,21 @@ public class FopubFacade {
      * @param distDir the directory to write the PDF to
      * @throws Exception
      */
-    public void renderPdf(File sourceDocument, File workingDir, File distDir) throws Exception {
+    public void renderPdf(File sourceDocument, File workingDir, File distDir, FopubOptions options) throws Exception {
         setupWorkingDir(workingDir);
 
-        Vector params = createParams(workingDir);
+        Vector params = createParams(workingDir, options.getParams());
 
         String fileNamePattern = "\\..*";
         String documentName = sourceDocument.getName();
         File outputFile = new File(distDir, documentName.replaceAll(fileNamePattern, ".pdf"));
         File docbookFile = new File(distDir,documentName.replaceAll(fileNamePattern,".xml"));
-        File xsltFile = new File(workingDir, "docbook-xsl/fo-pdf.xsl");
+        File xsltFile;
+        if (options.getXsltFile()!=null) {
+            xsltFile = options.getXsltFile();
+        } else {
+            xsltFile = new File(workingDir, "docbook-xsl/fo-pdf.xsl");
+        }
 
         FopFactory fopFactory = FopFactory.newInstance(); // Reuse the FopFactory if possible!
         fopFactory.setUserConfig(new File(workingDir, "docbook-xsl/fop-config.xml"));
@@ -108,7 +114,7 @@ public class FopubFacade {
         unzipDockbookXsl(workingDir);
     }
 
-    private Vector createParams(File workingDir) {
+    private Vector createParams(File workingDir, Map<Object, Object> options) {
         String outputUri = workingDir.toURI().toASCIIString();
 
         Vector params = new Vector();
@@ -124,6 +130,12 @@ public class FopubFacade {
         params.add("application/pdf");
         params.add("fop-version");
         params.add("1.1");
+        if (options!=null) {
+            for (Object key: options.keySet()) {
+                params.add(key.toString());
+                params.add(options.get(key).toString());
+            }
+        }
         return params;
     }
 

--- a/src/main/groovy/org/asciidoctor/gradle/FopubOptions.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/FopubOptions.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle
+
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
+
+/**
+ * @author Stefan Schlott
+ */
+@groovy.transform.ToString
+class FopubOptions {
+    @Optional @InputFile File xsltFile
+    @Input Map params = [:]
+}

--- a/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskSpec.groovy
+++ b/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskSpec.groovy
@@ -61,7 +61,7 @@ class AsciidoctorTaskSpec extends Specification {
             task.gititdone()
         then:
             2 * mockAsciidoctor.renderFile(_, { Map map -> map.backend == 'docbook'})
-            2 * mockFopub.renderPdf(_, _, _)
+            2 * mockFopub.renderPdf(_, _, _, new FopubOptions())
     }
 
     @SuppressWarnings('MethodName')
@@ -81,7 +81,7 @@ class AsciidoctorTaskSpec extends Specification {
         then:
             2 * mockAsciidoctor.renderFile(_, { Map map -> map.backend == 'docbook'})
             2 * mockAsciidoctor.renderFile(_, { Map map -> map.backend == 'html5'})
-            2 * mockFopub.renderPdf(_, _, _)
+            2 * mockFopub.renderPdf(_, _, _, new FopubOptions())
     }
 
     @SuppressWarnings('MethodName')


### PR DESCRIPTION
Separate configuration section for fopub options. Allows to:
- pass parameters to the XSL stylesheet
- define a custom XSL stylesheet (instead of the included fo-pdf.xsl)

The modified fopub sample shows the usage of the options; the example now changes the output to landscape and modifies the font color by passing parameters to the default XSL file.
