### PR TITLE
Changed attribute name and type template_dir

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -78,7 +78,7 @@ These attributes may be overridden by explicit user input.
 The following options may be set using the task's `options` property
 
  * header_footer - boolean
- * template_dir - String
+ * template_dirs - List<String>
  * template_engine - String
  * compact - boolean
  * doctype - String


### PR DESCRIPTION
The name of the attribute template_dir is in AsciidoctorJ template_dirs. The value must be a List of String values. See also org.asciidoctor.Options#TEMPLATE_DIRS. 
