### PR TITLE
Add epub3 as a built-in backend name

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorBackend.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorBackend.groovy
@@ -22,7 +22,7 @@ package org.asciidoctor.gradle
  * @author Dan Allen
  */
 enum AsciidoctorBackend {
-    HTML('html'), DOCBOOK('docbook'), HTML5('html5'), DOCBOOK45('docbook45'), DOCBOOK5('docbook5')
+    HTML('html'), DOCBOOK('docbook'), HTML5('html5'), DOCBOOK45('docbook45'), DOCBOOK5('docbook5'), EPUB3('epub3')
 
     private final static Map<String, AsciidoctorBackend> ALL_BACKENDS
     private final String id


### PR DESCRIPTION
This depends on the upgrade to AsciidoctorJ 1.5.0. AciidoctorJ handles all the details of calling the epub3 backend.
