### PR TITLE
resolves #96 attempt to configure AsciidoctorJ in isolation

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -157,7 +157,13 @@ class AsciidoctorTask extends DefaultTask {
                 asciidoctor = (loadClass('org.asciidoctor.Asciidoctor$Factory').create(gemPath) as AsciidoctorProxy)
             }
             else {
-                asciidoctor = (loadClass('org.asciidoctor.Asciidoctor$Factory').create() as AsciidoctorProxy)
+                try {
+                    asciidoctor = (loadClass('org.asciidoctor.Asciidoctor$Factory').create(null as String) as AsciidoctorProxy)
+                }
+                // Asciidoctor < 1.5.1 can't handle a null gemPath, so fallback to default create() method
+                catch (Exception e) {
+                    asciidoctor = (loadClass('org.asciidoctor.Asciidoctor$Factory').create() as AsciidoctorProxy)
+                }
             }
         }
 


### PR DESCRIPTION
Rough cut of configuring AsciidoctorJ in isolation. Note that this commit will conflict with the pull request for the custom gemPath...so we'll need to resolve that first.
