### PR TITLE
README.adoc revision

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -26,9 +26,9 @@ This is a port of the {asciidoctor-maven-plugin}[Asciidoctor Maven Plugin] proje
 
 Use the following snippet inside a Gradle build file:
 
-.build.gradle
 [source,groovy]
 [subs="attributes"]
+.build.gradle
 ----
 buildscript {
     repositories {
@@ -45,7 +45,7 @@ apply plugin: 'org.asciidoctor.gradle.asciidoctor'
 
 == Usage
 
-The plugin adds a new task named `asciidoctor`. This task exposes a few properties as part of its configuration
+The plugin adds a new task named `asciidoctor`. This task exposes a few properties as part of its configuration.
 
 [horizontal]
 sourceDir:: where the asciidoc sources are. Type: File. Default: `src/asciidoc`.
@@ -58,14 +58,14 @@ logDocuments:: a boolean specifying if documents being processed should be logge
 gemPath:: one or more gem installation directories (separated by the system path separator). Type: String. Default: `null`
 requires:: a set of Ruby modules to be included. Type: Set<String>. Default: empty.
 
-Sources may have any of the following extensions in order to be discovered
+Sources may have any of the following extensions in order to be discovered:
 
  * .asciidoc
  * .adoc
  * .asc
  * .ad
 
-The following attributes are automatically set by the `Asciidoctor` task
+The following attributes are automatically set by the `asciidoctor` task:
 
  * project-name : matches `$project.name`
  * project-version: matches `$project.version` (if defined). Empty String value if undefined
@@ -91,22 +91,22 @@ it's no longer possible to process documents placed outside of the project's sou
 
 == Configuration
 
-This plugin uses `asciidoctorj-1.5.0` by default, however you can change this by
+This plugin uses `asciidoctorj-1.5.0` by default, however, you can change this by
 defining a value on the +asciidoctorj+ extension, like so
 
-.build.gradle
 [source,groovy]
+.build.gradle
 ----
 asciidoctorj {
-    version = '1.6.0.SNAPSHOT'
+    version = '1.6.0-SNAPSHOT'
 }
 ----
 
-Do not forgte to add an entry to the `repositories` block pointint to Maven local if you'd like to run a local version
-of Asciidoctor (such as an snapshot build for testing bleeding edge features). The following snippet is all you need
+Do not forget to add an entry to the `repositories` block pointing to Maven local if you'd like to run a local version
+of Asciidoctorj (such as an snapshot build for testing bleeding edge features). The following snippet is all you need.
 
-.build.gradle
 [source,groovy]
+.build.gradle
 ----
 repositories {
     mavenLocal() // <1>
@@ -114,7 +114,7 @@ repositories {
 }
 
 asciidoctorj {
-    version = '1.6.0.MY_SNAPSHOT'
+    version = '1.6.0-MY_SNAPSHOT'
 }
 ----
 <1> resolves artifacts in your local Maven repository
@@ -128,11 +128,11 @@ The following options may be set using the task's `options` property
  * doctype - String
  * attributes - Map
 
-Any key/values set on `attributes` are sent as is to Asciidoctor. You may use this Map to specify
-an stylesheet for example. The following snippet shows a sample configuration defining attributes
+Any key/values set on `attributes` is sent as is to Asciidoctor. You may use this Map to specify
+a stylesheet for example. The following snippet shows a sample configuration defining attributes.
 
-.build.gradle
 [source,groovy]
+.build.gradle
 ----
 asciidoctor { <1>
     outputDir = new File("$buildDir/docs")
@@ -147,22 +147,22 @@ asciidoctor { <1>
     ]
 }
 ----
-<1> append below the line: `apply plugin: 'org.asciidoctor.gradle.asciidotor'`
+<1> append below the line: `apply plugin: 'org.asciidoctor.gradle.asciidoctor'`
 
 You may need to include extra content into the head of the exported document.
 For example, you might want to include jQuery inside the `<head>` element of the HTML export.
 To do so, first create a docinfo file `src/asciidoc/docinfo.html` containing the content to include, in this case the `<script>` tag to load jQuery.
 
-.src/asciidoc/docinfo.html
 [source,html]
+.src/asciidoc/docinfo.html
 ----
-<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.js"></script>
+<script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.js"></script>
 ----
 
 Then, add the `docinfo1` attribute to the attributes list in the previous example:
 
-.build.gradle
 [source,groovy]
+.build.gradle
 ----
 attributes: [
     // ...
@@ -171,10 +171,10 @@ attributes: [
 ]
 ----
 
-The value of `attributes` my be specified as a Map, List, Array or String, for example the following Map definition
+The value of `attributes` my be specified as a Map, List, Array or String, for example the following Map definition:
 
-.build.gradle
 [source,groovy]
+.build.gradle
 ----
 options = [
     attributes: [
@@ -187,8 +187,8 @@ options = [
 
 may be rewritten in List/Array form as follows
 
-.build.gradle
 [source,groovy]
+.build.gradle
 ----
 options = [
     attributes: [
@@ -201,8 +201,8 @@ options = [
 
 or in String form like so
 
-.build.gradle
 [source,groovy]
+.build.gradle
 ----
 options = [
     attributes: 'toc=right source-highlighter=coderay toc-title=Table\\ of\\ Contents'
@@ -219,15 +219,15 @@ Refer to the {asciidoctor-docs}[Asciidoctor documentation] to learn more about t
 == Custom Extensions
 
 Starting with version 1.5.0 you'll be able to write your own Asciidoctor extensions in Groovy, or any other JVM language
-for that matter. There are several options for you to make it happen
+for that matter. There are several options for you to make it happen.
 
 === External Library
 
 This is the most versatile option, as it allows you to reuse the same extension in different projects. An external library
 is just like any other Java/Groovy project. You simply define a dependency using the `asciidoctor` configuration.
 
-.build.gradle
 [source,groovy]
+.build.gradle
 ----
 dependencies {
     asciidoctor 'com.acme:asciidoctor-extensions:x.y.z'
@@ -238,7 +238,7 @@ dependencies {
 
 The next option is to host the extension project in a multi-project build. This allows for a much quicker development cycle
 as you don't have to publish the jar to a repository every time you make adjustments to the code. Take for example the
-following setup
+following setup:
 
 [source]
 ----
@@ -268,11 +268,11 @@ following setup
 └── settings.gradle
 ----
 
-The `extension` project is a sibling for `core`. The build file for the latter looks like this
+The `extension` project is a sibling for `core`. The build file for the latter looks like this:
 
-.build.gradle
 [source,groovy]
 [subs="attributes"]
+.build.gradle
 ----
 buildscript {
     repositories {
@@ -298,5 +298,5 @@ dependencies {
 === Build Dependency
 
 The last option is to move the `extension` project into Gradle's `buildSrc` directory. There are no additional dependencies
-that must defined on the consuming projects, as the extension will be automatically picked up by the `asciidoctor` task,
+to be defined on the consuming projects, as the extension will be automatically picked up by the `asciidoctor` task,
 as the compiled extension is already in the task's classpath.


### PR DESCRIPTION
Several changes to improve readme.adoc (started as a minnor typo-fixing). 
- changed ending punctuation. Added . where missing and : where deemed appropiate. Checked with other asciidoctor documentation like the maven-plugin or the reference.
- changed . by - in asciidoctor snapshot to be the same as its real format (that's maybe, beign to picky)
- changed order of titles in blocks according to asciidoc syntax reference. The current configuration works but the syntax reference and other docs use the opposite position. See, 'Code block with title and syntax highlighting' in http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#source-code
- some typos corrected
