### PR TITLE
Fixing #112

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -162,6 +162,9 @@ class AsciidoctorTask extends DefaultTask {
 
     @TaskAction
     void processAsciidocSources() {
+        if(classpath == null) {
+            classpath = project.configurations.getByName(AsciidoctorPlugin.ASCIIDOCTOR)
+        }
         validateInputs()
         outputDir.mkdirs()
 

--- a/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskSpec.groovy
+++ b/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskSpec.groovy
@@ -50,6 +50,7 @@ class AsciidoctorTaskSpec extends Specification {
 
     def setup() {
         project = ProjectBuilder.builder().withName('test').build()
+        project.configurations.create(ASCIIDOCTOR)
         mockAsciidoctor = Mock(AsciidoctorProxy)
         testRootDir = new File('.')
         srcDir = new File(testRootDir, ASCIIDOC_RESOURCES_DIR)
@@ -600,4 +601,5 @@ class AsciidoctorTaskSpec extends Specification {
         then:
             1 * mockAsciidoctor.renderFile(_, _)
     }
+
 }


### PR DESCRIPTION
The fix is pretty simple, but there is no associated unittest. I have manually tested it by using the gradle scirpt as shown in #112.

The reason I have no unittest is due to the present `testCompile 'org.asciidoctor:asciidoctorj:1.5.0'` line in `build.gradle`. This places `asciidoctorj` on the classpath, rendering half of the `setupClassloader` function during unit testing useless. In order to reproduce the problem, one needs to run with a test configuration that does not have `asciidoctorj` as a dependency. Just removing it does not work as it will break `AsciidoctorTaskSpec`. It was not worth the effort at present.

The fix itself it pretty simple - when the task action is executed and the (not so aptly named) `classpath` property is null, then set it to `project.configurations.asciidoctor`.
