### PR TITLE
A better fix for #113

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -84,7 +84,15 @@ class AsciidoctorTask extends DefaultTask {
     @InputFiles
     FileCollection getSourceDocumentNames() { project.files(this.sourceDocumentNames) }
 
-    void setSourceDocumentNames(Object... src) { this.sourceDocumentNames.addAll(src as List) }
+    void setSourceDocumentNames(Object... src) {
+        this.sourceDocumentNames.clear()
+        sourceDocumentNames(src)
+    }
+
+    @SuppressWarnings('ConfusingMethodName')
+    void sourceDocumentNames(Object... src) {
+        this.sourceDocumentNames.addAll(src as List)
+    }
 
     void setBaseDir(File baseDir) {
         this.baseDir = baseDir


### PR DESCRIPTION
I believe that the following is more semantically correct fix for #113. It builds upon what @aalmiray has already done. 

It breaks current form of property assignment in the plugin to get closer to Gradle convention

``` groovy
sourceDocumentNames 'one.adoc', 'two.adoc'
sourceDocumentNames files('three.adoc','four.adoc')
sourceDocumentNames new File(projectDir,'src/asciidoc/four.adoc')
sourceDocumentNames {'five.adoc'}
```

In line with convention, now doing

``` groovy
setSourceDocumentNames 'six.adoc'
```

will remove previous documents. I don't really see much of a use-case at present for this, so maybe we should throw this method out completely. It does however match behaviour with other gradle plugins

This does leave us with a dilemma that from a user perspective it is different to all of the other _calls_ in the configuration closure, but I actually think we should change most of them as well as some point. (I can raise a seperate issue for this).
