### PR TITLE
Upgrade asciidoctorj-groovy-dsl to 1.0.0.Alpha1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ repositories {
 dependencies {
     compile gradleApi()
     testCompile 'org.asciidoctor:asciidoctorj:1.5.2'
-    testCompile 'org.asciidoctor:asciidoctorj-groovy-dsl:1.0.0.preview2'
+    testCompile 'org.asciidoctor:asciidoctorj-groovy-dsl:1.0.0.Alpha1'
     testCompile('org.spockframework:spock-core:1.0-groovy-2.3') {
         exclude group: 'org.codehaus.groovy', module: 'groovy-all'
         exclude group: 'org.hamcrest', module: 'hamcrest-core'

--- a/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskInlineExtensionsSpec.groovy
+++ b/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskInlineExtensionsSpec.groovy
@@ -189,7 +189,7 @@ class AsciidoctorTaskInlineExtensionsSpec extends Specification {
                 sourceDocumentNames = [ASCIIDOC_INLINE_EXTENSIONS_FILE]
                 outputDir = outDir
                 extensions {
-                    includeprocessor (filter: {it.startsWith('http')}) {
+                    include_processor (filter: {it.startsWith('http')}) {
                         document, reader, target, attributes ->
                         reader.push_include(content, target, target, 1, attributes);
                     }


### PR DESCRIPTION
This PR bumps asciidoctorj-groovy-dsl to the last version 1.0.0.Alpha1.

"Highlights" of this release are:
- Dependencies on groovy is bumped to the same version as the gradle plugin. (Required some changes in the DSL base script class)
- Methods inlinemacro, includeprocessor, blockmacro are deprecated now.
  Instead the methods inline_macro, include_processor and block_macro should be used in the future.
- A new method docinfo_processor allows to define docinfo processors.

```
extensions {
  docinfo_processor {
    document -> '<meta name="hello" content="world">'
  }
}
```