### PR TITLE
AsciidoctorUtils.getRelativePath with same target and base

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorUtils.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorUtils.groovy
@@ -46,16 +46,19 @@ class AsciidoctorUtils {
         if (index != baseComponents.length) {
             // backtrack to base directory
             for (int i = index; i < baseComponents.length; ++i) {
-                result.append('..' + File.separator)
+                if (i != index) {
+                    result.append(File.separator)
+                }
+                result.append('..')
             }
         }
-        for (; index < targetComponents.length; ++index) {
-            result.append(targetComponents[index] + File.separator)
+        for (int i = index; i < targetComponents.length; ++i) {
+            if (i != index) {
+                result.append(File.separator)
+            }
+            result.append(targetComponents[i])
         }
-        if (!target.path.endsWith('/') && !target.path.endsWith('\\')) {
-            // remove final path separator
-            result.delete(result.length() - File.separator.length(), result.length())
-        }
+
         result.toString()
     }
 }

--- a/src/test/groovy/org/asciidoctor/gradle/AsciidoctorUtilsSpec.groovy
+++ b/src/test/groovy/org/asciidoctor/gradle/AsciidoctorUtilsSpec.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle
+
+import spock.lang.Specification
+
+class AsciidoctorUtilsSpec extends Specification {
+
+    static s = File.separator
+
+    def 'finds relative paths'(String target, String base, String relative) {
+        expect:
+            AsciidoctorUtils.getRelativePath(new File(target), new File(base)) == relative
+        where:
+            target             | base               | relative
+            'src/test/groovy'  | 'src'              | "test${s}groovy"
+            'src/test/groovy/' | 'src/'             | "test${s}groovy"
+            'src/test/groovy'  | 'src/'             | "test${s}groovy"
+            'src/test/groovy/' | 'src'              | "test${s}groovy"
+            'src'              | 'src/test/groovy'  | "..${s}.."
+            'src/'             | 'src/test/groovy/' | "..${s}.."
+            'src'              | 'src/test/groovy/' | "..${s}.."
+            'src/'             | 'src/test/groovy'  | "..${s}.."
+            'src/test'         | 'src/test'         | ''
+            'src/test/'        | 'src/test/'        | ''
+            'src/test'         | 'src/test/'        | ''
+            'src/test/'        | 'src/test'         | ''
+    }
+}


### PR DESCRIPTION
When trying to perform Asciidoctor conversion on files in root of the
project, i.e. when AsciidoctorUtils.getRelativePath receives exact
target and base directories the build results in failure caused by
StringIndexOutOfBoundsException on line 57. This patch resolves this
corner case and adds tests for other cases.