### PR TITLE
use published version in examples in README.adoc

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -1,4 +1,6 @@
 = Asciidoctor Hacking Guide
+:version: 1.5.3-SNAPSHOT
+:project-name: asciidoctor-gradle-plugin
 
 This is a guide to contributing to the Aciidoctor plugin for Gradle. (It is still very much work-in-progress)
 
@@ -16,4 +18,21 @@ which might bring incompatibility problems.
 
 If you need to work with snapshots consider building locally and publishing to your local `~/.m2`. This can be achieved
 by running `./gradlew build install`.
+You can then use the snapshot in your Gradle build as follows:
 
+[source,groovy]
+[subs="attributes,specialcharacters"]
+.build.gradle
+----
+buildscript {
+    repositories {
+        mavenLocal()
+    }
+
+    dependencies {
+        classpath 'org.asciidoctor:{project-name}:{version}'
+    }
+}
+
+apply plugin: 'org.asciidoctor.convert'
+----

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,7 @@
 = Asciidoctor Gradle Plugin
 Andres Almiray <https://github.com/aalmiray[@aalmiray]>
 :version: 1.5.3-SNAPSHOT
+:version-published: 1.5.2
 :asciidoc-url: http://asciidoc.org
 :asciidoctor-url: http://asciidoctor.org
 :issues: https://github.com/asciidoctor/asciidoctor-maven-plugin/issues
@@ -35,7 +36,7 @@ Thank you!
 Use the following snippet inside a Gradle build file:
 
 [source,groovy]
-[subs="attributes"]
+[subs="attributes,specialcharacters"]
 .build.gradle
 ----
 buildscript {
@@ -44,7 +45,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.asciidoctor:{project-name}:{version}'
+        classpath 'org.asciidoctor:{project-name}:{version-published}'
     }
 }
 
@@ -363,7 +364,7 @@ following setup:
 The `extension` project is a sibling for `core`. The build file for the latter looks like this:
 
 [source,groovy]
-[subs="attributes"]
+[subs="attributes,specialcharacters"]
 .build.gradle
 ----
 buildscript {
@@ -372,7 +373,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:{version}'
+        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:{version-published}'
     }
 }
 


### PR DESCRIPTION
- use published version in examples in README.adoc
- show example of using SNAPSHOT version in HACKING.adoc
- fix missing specialcharacters sub on source blocks