### PR TITLE
Flexibility to turn jcenter as default repo off

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -309,6 +309,16 @@ asciidoctorj {
 <1> resolves artifacts in your local Maven repository
 <2> resolves artifacts in Bintray's jcenter (where all other dependencies are found)
 
+The plugin also adds Bintray's JCenter as a default repository as the place to looks for `asciidocotorj`. In some contexts
+this behaviour can be considered detrimental or unwanted. In such cases this behaviour can be turned off by doing
+
+[source,groovy]
+----
+asciidoctorj {
+  noDefaultRepositories = true
+}
+----
+
 == Custom Extensions
 
 Starting with version 1.5.0 you'll be able to write your own Asciidoctor extensions in Groovy, or any other JVM language

--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorExtension.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorExtension.groovy
@@ -25,6 +25,13 @@ class AsciidoctorExtension {
 
     String groovyDslVersion = '1.0.0.preview2'
 
+    /**
+     * By default the plugin will try to add a default repository to find AsciidoctorJ.
+     * For certain cases this approach is not acceptable, the behaviour can be turned off
+     * by setting this value to {@code true}
+     */
+    boolean noDefaultRepositories = false
+
     final Project project
 
     AsciidoctorExtension(Project project) {

--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorExtension.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorExtension.groovy
@@ -29,6 +29,8 @@ class AsciidoctorExtension {
      * By default the plugin will try to add a default repository to find AsciidoctorJ.
      * For certain cases this approach is not acceptable, the behaviour can be turned off
      * by setting this value to {@code true}
+     *
+     * @since 1.6.0
      */
     boolean noDefaultRepositories = false
 

--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorPlugin.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorPlugin.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
  * @author Andres Almiray
  * @author Patrick Reimers
  * @author Markus Schlichting
+ * @author Schalk W. Cronjé
  */
 class AsciidoctorPlugin implements Plugin<Project> {
     static final String ASCIIDOCTOR = 'asciidoctor'
@@ -39,8 +40,12 @@ class AsciidoctorPlugin implements Plugin<Project> {
 
         AsciidoctorExtension extension = project.extensions.create(ASCIIDOCTORJ, AsciidoctorExtension, project)
 
-        project.repositories {
-            jcenter()
+        project.afterEvaluate {
+            if(!project.extensions.asciidoctorj.noDefaultRepositories) {
+                project.repositories {
+                    jcenter()
+                }
+            }
         }
 
         Configuration configuration = project.configurations.maybeCreate(ASCIIDOCTOR)

--- a/src/test/groovy/org/asciidoctor/gradle/AsciidoctorPluginSpec.groovy
+++ b/src/test/groovy/org/asciidoctor/gradle/AsciidoctorPluginSpec.groovy
@@ -81,4 +81,24 @@ class AsciidoctorPluginSpec extends Specification {
         assert dependencies.contains(dependencyHandler.create(AsciidoctorPlugin.ASCIIDOCTORJ_GROOVY_DSL_DEPENDENCY + expectedDslVersion))
         assert dependencies.contains(dependencyHandler.create(AsciidoctorPlugin.ACSIIDOCTORJ_CORE_DEPENDENCY + expectedVersion))
     }
+
+    def "JCenter repository is added by default"() {
+        when:
+        project.apply plugin : AsciidoctorPlugin
+        project.evaluate()
+
+        then:
+        project.repositories.findByName('BintrayJCenter')
+    }
+
+    def "JCenter repository must not be added when noDefaultRepositories is set"() {
+        when:
+        project.apply plugin : AsciidoctorPlugin
+        project.extensions.asciidoctorj.noDefaultRepositories = true
+        project.evaluate()
+
+        then:
+        project.repositories.findByName('BintrayJCenter') == null
+    }
 }
+


### PR DESCRIPTION
This addresses #174 by adding a `noDefaultRepositories` property to `asciidoctorj` extension block.