### PR TITLE
Use Asciidoctor.requireLibraries() to require gems instead of directl…

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorProxy.java
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorProxy.java
@@ -23,4 +23,6 @@ import java.util.Map;
  */
 public interface AsciidoctorProxy {
     String renderFile(File filename, Map<String, Object> options);
+
+    void requireLibrary(String... requiredLibraries);
 }

--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorProxyImpl.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorProxyImpl.groovy
@@ -25,4 +25,9 @@ class AsciidoctorProxyImpl implements AsciidoctorProxy {
     String renderFile(File filename, Map<String, Object> options) {
         delegate.renderFile(filename, options)
     }
+
+    @Override
+    void requireLibrary(String... requiredLibraries) {
+        delegate.requireLibrary(requiredLibraries)
+    }
 }

--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -583,9 +583,7 @@ class AsciidoctorTask extends DefaultTask {
 
         if (requires) {
             for (require in requires) {
-                // FIXME AsciidoctorJ should provide a public API for requiring paths in the Ruby runtime
-                asciidoctor.delegate.rubyRuntime.evalScriptlet(
-                    'require \'' + require.replaceAll('[^A-Za-z0-9/\\\\.\\-_]', '') + '\'')
+                asciidoctor.requireLibrary(require)
             }
         }
 

--- a/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskSpec.groovy
+++ b/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskSpec.groovy
@@ -1105,4 +1105,24 @@ class AsciidoctorTaskSpec extends Specification {
                 props.attributes.foo.class == String
             })
     }
+
+    @SuppressWarnings('MethodName')
+    def "Should require libraries"() {
+        expect:
+        project.tasks.findByName(ASCIIDOCTOR) == null
+        when:
+        Task task = project.tasks.create(name: ASCIIDOCTOR, type: AsciidoctorTask) {
+            asciidoctor = mockAsciidoctor
+            resourceCopyProxy = mockCopyProxy
+            sourceDir = srcDir
+            outputDir = outDir
+            sourceDocumentName = new File(srcDir, ASCIIDOC_SAMPLE_FILE)
+            requires 'asciidoctor-pdf'
+        }
+
+        task.processAsciidocSources()
+        then:
+        1 * mockAsciidoctor.requireLibrary("asciidoctor-pdf")
+    }
+
 }


### PR DESCRIPTION
…y grabbing into the Ruby runtime

This PR fixes asciidoctor/asciidoctorj#432

