### PR TITLE
Bump asciidoctorj-groovy-dsl to current version 1.0.0.Alpha2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
 asciidoctorjVersion    = 1.5.5
-asciidoctorjDslVersion = 1.0.0.Alpha1
+asciidoctorjDslVersion = 1.0.0.Alpha2
 #asciidoctorjDslVersion = 1.6.0-alpha.1
 cglibVersion           = 3.2.5
 jacocoVersion          = 0.7.9

--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorExtension.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorExtension.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.Project
 class AsciidoctorExtension {
     String version = '1.5.5'
 
-    String groovyDslVersion = '1.6.0-alpha.1'
+    String groovyDslVersion = '1.0.0.Alpha2'
 
     /**
      * By default the plugin will try to add a default repository to find AsciidoctorJ.


### PR DESCRIPTION
As pointed out in asciidoctor/asciidoctorj-groovy-dsl#14 the current released version of the asciidoctor-gradle-plugin uses old versions of the asciidoctorj-groovy-dsl.
This PR sets the dependency to the current version again.