### PR TITLE
Make Asciidoc task much faster by reusing JRuby runtime.

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorProxyCacheKey.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorProxyCacheKey.groovy
@@ -13,20 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.asciidoctor.gradle;
+package org.asciidoctor.gradle
 
-import java.io.File;
-import java.util.List;
-import java.util.Map;
+import groovy.transform.Immutable
 
 /**
- * @author andres Almiray
- */
-public interface AsciidoctorProxy {
-    String renderFile(File filename, Map<String, Object> options);
-
-    void requireLibrary(String... requiredLibraries);
-
-    void registerExtensions(List<Object> extensions);
-    void unregisterAllExtensions();
+ * @author Rene Groeschke
+ * */
+@Immutable
+class AsciidoctorProxyCacheKey {
+    final List<File> classpath
+    final String gemPath
+//    final List<Object> extensions
 }

--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorProxyCacheKey.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorProxyCacheKey.groovy
@@ -24,5 +24,4 @@ import groovy.transform.Immutable
 class AsciidoctorProxyCacheKey {
     final List<File> classpath
     final String gemPath
-//    final List<Object> extensions
 }

--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorProxyImpl.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorProxyImpl.groovy
@@ -20,6 +20,7 @@ package org.asciidoctor.gradle
  */
 class AsciidoctorProxyImpl implements AsciidoctorProxy {
     def delegate
+    def extensionRegistry
 
     @Override
     String renderFile(File filename, Map<String, Object> options) {
@@ -29,5 +30,16 @@ class AsciidoctorProxyImpl implements AsciidoctorProxy {
     @Override
     void requireLibrary(String... requiredLibraries) {
         delegate.requireLibrary(requiredLibraries)
+    }
+
+    @Override
+    void registerExtensions(List<Object> extensions) {
+        extensions.each { extensionRegistry.extensions(it) }
+        extensionRegistry.registerTo(delegate)
+    }
+
+    @Override
+    void unregisterAllExtensions() {
+        delegate.unregisterAllExtensions()
     }
 }

--- a/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskInlineExtensionsSpec.groovy
+++ b/src/test/groovy/org/asciidoctor/gradle/AsciidoctorTaskInlineExtensionsSpec.groovy
@@ -51,7 +51,6 @@ class AsciidoctorTaskInlineExtensionsSpec extends Specification {
         outDir = new File(project.projectDir, ASCIIDOC_BUILD_DIR)
     }
 
-
     def "Should apply inline BlockProcessor"() {
         given:
             Task task = project.tasks.create(name: ASCIIDOCTOR, type: AsciidoctorTask) {
@@ -105,18 +104,17 @@ class AsciidoctorTaskInlineExtensionsSpec extends Specification {
             resultFile.getText().contains("and write this in lowercase")
     }
 
-
     def "Should apply inline Postprocessor"() {
         given:
-            String copyright = "Copyright Acme, Inc." + System.currentTimeMillis()
-            Task task = project.tasks.create(name: ASCIIDOCTOR, type: AsciidoctorTask) {
-                sourceDir = srcDir
-                sourceDocumentNames = [ASCIIDOC_INLINE_EXTENSIONS_FILE]
-                outputDir = outDir
-                extensions {
-                    postprocessor {
-                        document, String output ->
-                        if(document.basebackend("html")) {
+        String copyright = "Copyright Acme, Inc." + System.currentTimeMillis()
+        Task task = project.tasks.create(name: ASCIIDOCTOR, type: AsciidoctorTask) {
+            sourceDir = srcDir
+            sourceDocumentNames = [ASCIIDOC_INLINE_EXTENSIONS_FILE]
+            outputDir = outDir
+            extensions {
+                postprocessor {
+                    document, String output ->
+                        if (document.basebackend("html")) {
                             Document doc = Jsoup.parse(output, "UTF-8")
 
                             Element contentElement = doc.getElementById("footer-text")
@@ -126,80 +124,80 @@ class AsciidoctorTaskInlineExtensionsSpec extends Specification {
                         } else {
                             throw new IllegalArgumentException("Expected html!")
                         }
-                    }
                 }
             }
-            File resultFile = new File(outDir, 'html5' + File.separator + ASCIIDOC_INLINE_EXTENSIONS_RESULT_FILE)
+        }
+        File resultFile = new File(outDir, 'html5' + File.separator + ASCIIDOC_INLINE_EXTENSIONS_RESULT_FILE)
         when:
-            task.processAsciidocSources()
+        task.processAsciidocSources()
         then:
-            resultFile.exists()
-            resultFile.getText().contains(copyright)
-            resultFile.getText().contains("Inline Extension Test document")
+        resultFile.exists()
+        resultFile.getText().contains(copyright)
+        resultFile.getText().contains("Inline Extension Test document")
     }
 
     def "Should fail if inline Postprocessor fails"() {
         given:
-            Task task = project.tasks.create(name: ASCIIDOCTOR, type: AsciidoctorTask) {
-                sourceDir = srcDir
-                sourceDocumentNames = [ASCIIDOC_INLINE_EXTENSIONS_FILE]
-                outputDir = outDir
-                extensions {
-                    postprocessor {
-                        document, output ->
+        Task task = project.tasks.create(name: ASCIIDOCTOR, type: AsciidoctorTask) {
+            sourceDir = srcDir
+            sourceDocumentNames = [ASCIIDOC_INLINE_EXTENSIONS_FILE]
+            outputDir = outDir
+            extensions {
+                postprocessor {
+                    document, output ->
                         if (output.contains("blacklisted")) {
                             throw new IllegalArgumentException("Document contains a blacklisted word")
                         }
-                    }
                 }
             }
+        }
         when:
-            task.processAsciidocSources()
+        task.processAsciidocSources()
         then:
-            thrown(GradleException)
+        thrown(GradleException)
     }
 
     def "Should apply inline Preprocessor"() {
         given:
-            Task task = project.tasks.create(name: ASCIIDOCTOR, type: AsciidoctorTask) {
-                sourceDir = srcDir
-                sourceDocumentNames = [ASCIIDOC_INLINE_EXTENSIONS_FILE]
-                outputDir = outDir
-                extensions {
-                    preprocessor {
-                        document, reader ->
+        Task task = project.tasks.create(name: ASCIIDOCTOR, type: AsciidoctorTask) {
+            sourceDir = srcDir
+            sourceDocumentNames = [ASCIIDOC_INLINE_EXTENSIONS_FILE]
+            outputDir = outDir
+            extensions {
+                preprocessor {
+                    document, reader ->
                         reader.advance()
                         reader
-                    }
                 }
             }
-            File resultFile = new File(outDir, 'html5' + File.separator + ASCIIDOC_INLINE_EXTENSIONS_RESULT_FILE)
+        }
+        File resultFile = new File(outDir, 'html5' + File.separator + ASCIIDOC_INLINE_EXTENSIONS_RESULT_FILE)
         when:
-            task.processAsciidocSources()
+        task.processAsciidocSources()
         then:
-            resultFile.exists()
-            !resultFile.getText().contains("Inline Extension Test document")
+        resultFile.exists()
+        !resultFile.getText().contains("Inline Extension Test document")
     }
 
     def "Should apply inline Includeprocessor"() {
         given:
-            String content = "The content of the URL " + System.currentTimeMillis()
-            Task task = project.tasks.create(name: ASCIIDOCTOR, type: AsciidoctorTask) {
-                sourceDir = srcDir
-                sourceDocumentNames = [ASCIIDOC_INLINE_EXTENSIONS_FILE]
-                outputDir = outDir
-                extensions {
-                    include_processor (filter: {it.startsWith('http')}) {
-                        document, reader, target, attributes ->
+        String content = "The content of the URL " + System.currentTimeMillis()
+        Task task = project.tasks.create(name: ASCIIDOCTOR, type: AsciidoctorTask) {
+            sourceDir = srcDir
+            sourceDocumentNames = [ASCIIDOC_INLINE_EXTENSIONS_FILE]
+            outputDir = outDir
+            extensions {
+                include_processor(filter: { it.startsWith('http') }) {
+                    document, reader, target, attributes ->
                         reader.push_include(content, target, target, 1, attributes);
-                    }
                 }
             }
-            File resultFile = new File(outDir, 'html5' + File.separator + ASCIIDOC_INLINE_EXTENSIONS_RESULT_FILE)
+        }
+        File resultFile = new File(outDir, 'html5' + File.separator + ASCIIDOC_INLINE_EXTENSIONS_RESULT_FILE)
         when:
-            task.processAsciidocSources()
+        task.processAsciidocSources()
         then:
-            resultFile.exists()
-            resultFile.getText().contains(content)
+        resultFile.exists()
+        resultFile.getText().contains(content)
     }
 }


### PR DESCRIPTION
This PR changes the AsciidocTask implementation to reuse the asciidoctor
instance to avoid reinstantiating the jruby runtime which is expensive.

Especially when running builds in continous mode with -t reusing the
asciidoctor instance solves two issues:

1. Everytime jruby runtime is loaded we see about > 5000 classes
leaking into the classloader

2. As a consequence of 1) the build gets slower and slower over time.

I've attached two profiling screenshots showing the impact of that change to classloader leakage when constantly running asciidoctor task in a gradle continous build (`./gradlew asciidoctor -t`):

Before:
<img width="999" alt="classloading-leakage-before-fix" src="https://user-images.githubusercontent.com/77300/29558908-d5f4d224-872d-11e7-9264-65e98b22470d.png">

After:
<img width="593" alt="classloading-leakage-after-fix" src="https://user-images.githubusercontent.com/77300/29558907-d5ce766a-872d-11e7-8fcf-521a5acebe9d.png">
