### PR TITLE
Make AsciidoctorTask cacheable

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTree
 import org.gradle.api.internal.file.copy.CopySpecInternal
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
@@ -52,6 +53,7 @@ import org.gradle.util.CollectionUtils
  * @author Robert Panzer
  */
 @SuppressWarnings(['MethodCount', 'Instanceof'])
+@CacheableTask
 class AsciidoctorTask extends DefaultTask {
     private static final boolean IS_WINDOWS = System.getProperty('os.name').contains('Windows')
     private static final String PATH_SEPARATOR = System.getProperty('path.separator')
@@ -451,11 +453,11 @@ class AsciidoctorTask extends DefaultTask {
      * @since 1.5.1
      */
     @OutputDirectories
-    Set<File> getOutputDirectories() {
+    Map<String, File> getOutputDirectories() {
         if (separateOutputDirs) {
-            backends.collect { new File(outputDir, it) } as Set
+            backends.collectEntries { [(it): new File(outputDir, it)] }
         } else {
-            [outputDir] as Set
+            [(outputDir.name): outputDir]
         }
     }
 


### PR DESCRIPTION
This activates caching for the Asciidoctor Gradle Plugin when Gradle's build cache is enabled (--build-cache). See: https://docs.gradle.org/4.1/userguide/build_cache.html

I am not sure if this can be merged as it is as it changes the API from

`@OutputDirectories Set<File> getOutputDirectories()`

to

`@OutputDirectories Map<String, File> getOutputDirectories()`

This is necessary because only `@OutputDirectories` that return a Map can be cached. See https://docs.gradle.org/4.1/userguide/more_about_tasks.html#sec:task_inputs_outputs