### PR TITLE
Ensure that AsciidoctorTask is not up-to-date when classpath changes

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -118,6 +118,9 @@ class AsciidoctorTask extends DefaultTask {
 
     AsciidoctorProxy asciidoctor
     ResourceCopyProxy resourceCopyProxy
+
+    @Optional
+    @InputFiles
     Configuration classpath
 
     AsciidoctorTask() {


### PR DESCRIPTION
Previously, the AsciidoctorTask did not consider its classpath to be an input. This meant that a change to task's classpath did not stop it from considering itself to be up-to-date.

This pull request annotates the classpath property with `@InputFiles` so that it's considered when performing up-to-date checks. It's also been annotated with `@Optional` as the property can be `null`.