### PR TITLE
Allow the project to be compiled on Java 10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,10 +148,6 @@ project.tasks.withType(Test) {
     }
 }
 
-jacoco {
-    toolVersion = jacocoVersion
-}
-
 jacocoTestReport {
     reports {
         xml.enabled = true // coveralls plugin depends on xml format report

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,5 @@ asciidoctorjVersion    = 1.5.6
 asciidoctorjDslVersion = 1.0.0.Alpha2
 #asciidoctorjDslVersion = 1.6.0-alpha.1
 cglibVersion           = 3.2.6
-jacocoVersion          = 0.8.0
 jsoupVersion           = 1.11.2
 spockVersion           = 1.1-groovy-2.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates Grade to 4.7.

Gradle 4.7 is the first gradle version which offically support running on Java 10.

This PR also implicitly updates JaCoCo from 0.8.0 to 0.8.1.