### PR TITLE
Allow Java fork options to be specified (#240)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -174,6 +174,9 @@ gemPaths:: One or more gem installation directories (separated by the system pat
   Default: empty
 groovyDslVersion:: Version of Groovy Extensions DSL.
   If not specified and no extensions are specified, Groovy DSL will not be used. However, if any extensions are added without setting an explicit version and default version will be used.
+logLevel:: The log level at which AsciidoctorJ will log.
+  This is specified as a GRadle loggin glevel. The plugin will translate it to the appropriate AsciidoctorJ logging level.
+  Default is `project.logger.level`.
 options: {asciidoctorj-name} options.
   Use `options` to append and `setOptions` to replace any current options with a new set.
   Options are evaluated as late as possible.
@@ -187,8 +190,6 @@ resolutionStrategy:: Strategies for resolving Asciidoctorj-related dependencies.
 safeMode: {asciidoctorj-name} safe mode.
   Set the Safe mode as either `UNSAFE`, `SAFE`, `SERVER`, `SECURE`.
   Can be a number (0, 1, 10, 20), a string, or the entity name
-verboseMode:: Asciidoctor verbose mode.
-  Default is `false`.
 version:: Asciidoctorj version.
   If not specified a version will be used.
 
@@ -431,6 +432,15 @@ If you do not want this behaviour, then it can be turned off by doing
 ----
 copyNoResources()
 ----
+
+=== Choosing a Process Mode
+
+All tasks can control how Asciidoctor conversions are being run via the `inProcess` property. This is early days, an choose for your build will depend very much on your context, but the following has already become clear:
+
+* `IN_PROCESS` and `OUT_OF_PROCESS` shuold theoretically run faster, especially if you continuously rebuild the same documentation. Gradle workers are the underlying implementation for these two options
+* The safe option is always `JAVA_EXEC`. For lower memory consumption this is by far the safer option. It is also the only way we can get the Windows-based tests for tjhis plugin completed on Appveyor. It you run a lot of builds the penalty statr-up time might become an issue for you.
+
+NOTE: In certain cases the plugin will overrule your choice as it has some built-in rules for special cases. In such cases it will log a warning that it has done that.
 
 == The New AsciidoctorJ Plugin
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+image: Visual Studio 2017
 version: '{build}'
 skip_tags: true
 skip_commits:
@@ -15,13 +16,13 @@ install:
 build_script:
   - gradlew.bat --console=plain --warning-mode=all -s clean assemble
 test_script:
-  - gradlew.bat --console=plain --warning-mode=all -s check --no-parallel
+  - gradlew.bat --console=plain --warning-mode=all -s check --no-parallel -Djava.net.preferIPv4Stack=true
 after_test:
   - gradlew.bat --stop
 cache:
   - .gradle
   - C:\Users\appveyor\.gradle
-  - testfixtures\offline-repo\build\root
+  - testfixtures\offline-repo\build\repo
 
 on_failure:
   - echo Somebody setup us the bomb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,9 @@ test_script:
 after_test:
   - gradlew.bat --stop
 cache:
-  - .gradle
   - C:\Users\appveyor\.gradle
   - testfixtures\offline-repo\build\repo
+  - .gradle
 
 on_failure:
   - echo Somebody setup us the bomb

--- a/asciidoctor-gradle-jvm/src/gradleTest/complex-jvm-setup/build.gradle
+++ b/asciidoctor-gradle-jvm/src/gradleTest/complex-jvm-setup/build.gradle
@@ -19,6 +19,8 @@ asciidoctorj {
     // gemPaths
 
     diagramVersion = '1.5.4.1'
+
+    logLevel = 'INFO'
 }
 
 configurations {
@@ -59,10 +61,6 @@ asciidoctorPdf {
 
     sources {
         include 'subdir/sample2.ad'
-    }
-
-    asciidoctorj {
-        verboseMode true
     }
 }
 

--- a/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/internal/FunctionalSpecification.groovy
+++ b/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/internal/FunctionalSpecification.groovy
@@ -38,8 +38,8 @@ class FunctionalSpecification extends Specification {
 
     @CompileStatic
     GradleRunner getGradleRunner(List<String> taskNames = ['asciidoctor']) {
-        FunctionalTestSetup.getGradleRunner(testProjectDir.root,pluginClasspath,taskNames)
-   }
+        FunctionalTestSetup.getGradleRunner(testProjectDir.root, pluginClasspath, taskNames)
+    }
 
     @SuppressWarnings(['FactoryMethodName', 'BuilderMethodWithSideEffects'])
     void createTestProject(String docGroup = 'normal') {
@@ -54,15 +54,23 @@ class FunctionalSpecification extends Specification {
     File getJvmConvertBuildFile(String extraContent) {
         File buildFile = testProjectDir.newFile('build.gradle')
         buildFile << """
-plugins {
-    id 'org.asciidoctor.jvm.convert'
-}
-
-${offlineRepositories}
-
-${extraContent}
-"""
+            plugins {
+                id 'org.asciidoctor.jvm.convert'
+            }
+            
+            ${offlineRepositories}
+            
+            ${extraContent}
+        """
         buildFile
+    }
+
+    String getDefaultProcessModeForAppveyor() {
+        if(System.getenv('APPVEYOR')) {
+            'inProcess = JAVA_EXEC'
+        } else {
+            ''
+        }
     }
 
 }

--- a/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorPdfTaskFunctionalSpec.groovy
+++ b/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorPdfTaskFunctionalSpec.groovy
@@ -72,6 +72,8 @@ asciidoctorPdf {
         getBuildFile("""
 asciidoctorPdf {
 
+    ${defaultProcessModeForAppveyor}
+
     asciidoctorj {
         version = '${asciidoctorjVer}'  
         jrubyVersion = '${jrubyVer}'

--- a/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskFunctionalSpec.groovy
+++ b/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskFunctionalSpec.groovy
@@ -30,8 +30,6 @@ import static org.asciidoctor.gradle.testfixtures.jvm.JRubyTestVersions.*
 class AsciidoctorTaskFunctionalSpec extends FunctionalSpecification {
 
     static final List<String> DEFAULT_ARGS = ['asciidoctor', '-s', '-i']
-    static final String VERBOSITY_FILE = 'build/tmp/asciidoctor/asciidoctor-verbose-mode.rb'
-    static final String VERBOSITY_CONTENT = '$VERBOSE = true'
 
     void setup() {
         createTestProject()
@@ -39,7 +37,7 @@ class AsciidoctorTaskFunctionalSpec extends FunctionalSpecification {
 
     @Issue('https://github.com/gradle/gradle/issues/3698')
     @Unroll
-    @Timeout(value=90)
+    @Timeout(value = 90)
     void 'Built-in backends (parallelMode=#parallelMode, asciidoctorj=#asciidoctorjVer, min jRuby=#jrubyVer, compatible=#compatible)'() {
         given:
         getBuildFile("""
@@ -94,7 +92,7 @@ class AsciidoctorTaskFunctionalSpec extends FunctionalSpecification {
         false        | AJ16_ABSOLUTE_MAXIMUM | SERIES_16       | true
     }
 
-    @Timeout(value=90)
+    @Timeout(value = 90)
     void 'Support attributes in various formats'() {
         given:
         getBuildFile("""
@@ -127,37 +125,11 @@ class AsciidoctorTaskFunctionalSpec extends FunctionalSpecification {
         noExceptionThrown()
     }
 
-    @Timeout(value=90)
-    void 'Run verbose mode'() {
-        given:
-        getBuildFile("""
-            asciidoctorj {
-                verboseMode = true
-            }
-                    
-            asciidoctor {
-                ${defaultProcessModeForAppveyor}
-            
-            
-                outputOptions {
-                    backends 'html5'
-                }
-                sourceDir 'src/docs/asciidoc'
-            }
-        """)
-
-        when:
-        getGradleRunner(DEFAULT_ARGS).build()
-
-        then:
-        new File(testProjectDir.root, VERBOSITY_FILE).text.contains(VERBOSITY_CONTENT)
-    }
-
     void 'Can run in JAVA_EXEC process mode'() {
         given:
         getBuildFile('''
             asciidoctorj {
-                verboseMode = true
+                logLevel = 'INFO'
             }
                     
             asciidoctor {
@@ -175,7 +147,7 @@ class AsciidoctorTaskFunctionalSpec extends FunctionalSpecification {
         getGradleRunner(DEFAULT_ARGS).build()
 
         then:
-        new File(testProjectDir.root, VERBOSITY_FILE).text.contains(VERBOSITY_CONTENT)
+        noExceptionThrown()
     }
 
     File getBuildFile(String extraContent) {

--- a/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskFunctionalSpec.groovy
+++ b/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskFunctionalSpec.groovy
@@ -18,6 +18,7 @@ package org.asciidoctor.gradle.jvm
 import org.asciidoctor.gradle.internal.FunctionalSpecification
 import org.gradle.testkit.runner.GradleRunner
 import spock.lang.Issue
+import spock.lang.Timeout
 import spock.lang.Unroll
 
 import static org.asciidoctor.gradle.testfixtures.jvm.AsciidoctorjTestVersions.SERIES_15
@@ -38,27 +39,32 @@ class AsciidoctorTaskFunctionalSpec extends FunctionalSpecification {
 
     @Issue('https://github.com/gradle/gradle/issues/3698')
     @Unroll
+    @Timeout(value=90)
     void 'Built-in backends (parallelMode=#parallelMode, asciidoctorj=#asciidoctorjVer, min jRuby=#jrubyVer, compatible=#compatible)'() {
         given:
         getBuildFile("""
-asciidoctor {
-    outputOptions {
-        backends 'html5', 'docbook'
-    }
+            asciidoctor {
 
-    asciidoctorj {
-        version = '${asciidoctorjVer}' 
-        jrubyVersion = '${jrubyVer}'
-    }
-    logDocuments = true
-    sourceDir 'src/docs/asciidoc'
-    parallelMode ${parallelMode}
+                ${defaultProcessModeForAppveyor}
 
-    doFirst {
-        logger.lifecycle 'Requested: asciidoctorj=${asciidoctorjVer}, jrubyVer=${jrubyVer}. Got configuration: ' + asciidoctorj.configuration.files*.name.join(' ')
-    }
-}
-""")
+                outputOptions {
+                    backends 'html5', 'docbook'
+                }
+            
+                asciidoctorj {
+                    version = '${asciidoctorjVer}' 
+                    jrubyVersion = '${jrubyVer}'
+                }
+                logDocuments = true
+                sourceDir 'src/docs/asciidoc'
+                parallelMode ${parallelMode}
+            
+                doFirst {
+                    logger.lifecycle 'Requested: asciidoctorj=${asciidoctorjVer}, jrubyVer=${jrubyVer}. Got configuration: ' + asciidoctorj.configuration.files*.name.join(' ')
+                }
+            }
+        """)
+
         GradleRunner runner = getGradleRunner(DEFAULT_ARGS)
 
         when:
@@ -75,42 +81,45 @@ asciidoctor {
         where:
         parallelMode | jrubyVer              | asciidoctorjVer | compatible
 //        true         | AJ15_ABSOLUTE_MINIMUM | SERIES_15       | true  // <- too brittle
-        true         | AJ15_ABSOLUTE_MINIMUM | SERIES_16       | true
+        true         | AJ16_ABSOLUTE_MINIMUM | SERIES_16       | true
         true         | AJ15_SAFE_MINIMUM     | SERIES_15       | true
-        true         | AJ15_SAFE_MINIMUM     | SERIES_16       | true
+        true         | AJ16_SAFE_MINIMUM     | SERIES_16       | true
         true         | AJ15_SAFE_MAXIMUM     | SERIES_15       | true
-        true         | AJ15_SAFE_MAXIMUM     | SERIES_16       | true
+        true         | AJ16_SAFE_MAXIMUM     | SERIES_16       | true
         false        | AJ15_ABSOLUTE_MINIMUM | SERIES_15       | true
         false        | AJ15_SAFE_MINIMUM     | SERIES_15       | true
         false        | AJ15_SAFE_MAXIMUM     | SERIES_15       | true
-        false        | AJ15_SAFE_MAXIMUM     | SERIES_16       | true
+        false        | AJ16_SAFE_MAXIMUM     | SERIES_16       | true
         true         | AJ15_ABSOLUTE_MAXIMUM | SERIES_15       | false
-        false        | AJ15_ABSOLUTE_MAXIMUM | SERIES_16       | true
+        false        | AJ16_ABSOLUTE_MAXIMUM | SERIES_16       | true
     }
 
+    @Timeout(value=90)
     void 'Support attributes in various formats'() {
         given:
-        getBuildFile('''
-asciidoctorj {
-    attributes attr1 : 'a string',
-        attr2 : "A GString",
-        attr10 : [ 'a', 2, 5 ]
-}
-        
-asciidoctor {
-    outputOptions {
-        backends 'html5'
-    }
-    logDocuments = true
-    sourceDir 'src/docs/asciidoc'
-    
-    asciidoctorj {
-        attributes attr3 : new File('abc'),
-            attr4 : { 'a closure' },
-            attr20 : [ a : 1 ]            
-    }
-}
-''')
+        getBuildFile("""
+            asciidoctorj {
+                attributes attr1 : 'a string',
+                    attr2 : "A GString",
+                    attr10 : [ 'a', 2, 5 ]
+            }
+                    
+            asciidoctor {
+                ${defaultProcessModeForAppveyor}
+            
+                outputOptions {
+                    backends 'html5'
+                }
+                logDocuments = true
+                sourceDir 'src/docs/asciidoc'
+                
+                asciidoctorj {
+                    attributes attr3 : new File('abc'),
+                        attr4 : { 'a closure' },
+                        attr20 : [ a : 1 ]            
+                }
+            }
+        """)
         when:
         getGradleRunner(DEFAULT_ARGS).build()
 
@@ -118,20 +127,25 @@ asciidoctor {
         noExceptionThrown()
     }
 
+    @Timeout(value=90)
     void 'Run verbose mode'() {
         given:
-        getBuildFile('''
-asciidoctorj {
-    verboseMode = true
-}
-        
-asciidoctor {
-    outputOptions {
-        backends 'html5'
-    }
-    sourceDir 'src/docs/asciidoc'
-}
-''')
+        getBuildFile("""
+            asciidoctorj {
+                verboseMode = true
+            }
+                    
+            asciidoctor {
+                ${defaultProcessModeForAppveyor}
+            
+            
+                outputOptions {
+                    backends 'html5'
+                }
+                sourceDir 'src/docs/asciidoc'
+            }
+        """)
+
         when:
         getGradleRunner(DEFAULT_ARGS).build()
 
@@ -142,39 +156,27 @@ asciidoctor {
     void 'Can run in JAVA_EXEC process mode'() {
         given:
         getBuildFile('''
-asciidoctorj {
-    verboseMode = true
-}
-        
-asciidoctor {
+            asciidoctorj {
+                verboseMode = true
+            }
+                    
+            asciidoctor {
+            
+                inProcess = JAVA_EXEC
+                
+                outputOptions {
+                    backends 'html5'
+                }
+                sourceDir 'src/docs/asciidoc'
+            }
+        ''')
 
-    inProcess = JAVA_EXEC
-    
-    outputOptions {
-        backends 'html5'
-    }
-    sourceDir 'src/docs/asciidoc'
-}
-''')
         when:
         getGradleRunner(DEFAULT_ARGS).build()
 
         then:
         new File(testProjectDir.root, VERBOSITY_FILE).text.contains(VERBOSITY_CONTENT)
     }
-
-//    void "When 'resources' not specified, then copy all images to backend"() {
-//    }
-//
-//    void "When 'resources' not specified and more than one backend, then copy all images to every backend"() {
-//    }
-//
-//    void "When 'resources' are specified, then copy according to all patterns"() {
-//    }
-//
-//    @SuppressWarnings('MethodName')
-//    void "Should require libraries"() {
-//    }
 
     File getBuildFile(String extraContent) {
         getJvmConvertBuildFile("""

--- a/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/RequiresFunctionalSpec.groovy
+++ b/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/RequiresFunctionalSpec.groovy
@@ -18,6 +18,7 @@ package org.asciidoctor.gradle.jvm
 import org.asciidoctor.gradle.internal.FunctionalSpecification
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Timeout
 
 import static org.asciidoctor.gradle.testfixtures.jvm.AsciidoctorjTestVersions.DIAGRAM_SERIES_15
 
@@ -35,6 +36,7 @@ class RequiresFunctionalSpec extends FunctionalSpecification {
         createTestProject('requires')
     }
 
+    @Timeout(value=360)
     def 'Asciidoctorj-diagram is registered and re-used across across multiple builds'() {
         given:
         final String imageFileExt = '.png'
@@ -60,6 +62,7 @@ class RequiresFunctionalSpec extends FunctionalSpecification {
         outputFolder.listFiles().findAll { it.name.endsWith(imageFileExt) }.size() == 1
     }
 
+    @Timeout(value=360)
     def 'Use asciidoctorj-diagram the old way way with `requires` still works'() {
         given:
         final String imageFileExt = '.png'
@@ -108,20 +111,21 @@ class RequiresFunctionalSpec extends FunctionalSpecification {
 
     File getBuildFile(String sourceName, String extraContent) {
         getJvmConvertBuildFile("""
-
-asciidoctorj {
-    diagramVersion = '${DIAGRAM_SERIES_15}'
-}
-
-asciidoctor {
-    sourceDir = 'src/docs/asciidoc'
-    
-    sources {
-        include '${sourceName}'
-    }
-}
-
-${extraContent}
-""")
+            asciidoctorj {
+                diagramVersion = '${DIAGRAM_SERIES_15}'
+            }
+            
+            asciidoctor {
+                ${defaultProcessModeForAppveyor}
+            
+                sourceDir = 'src/docs/asciidoc'
+                
+                sources {
+                    include '${sourceName}'
+                }
+            }
+            
+            ${extraContent}
+        """)
     }
 }

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/internal/AsciidoctorUtils.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/internal/AsciidoctorUtils.groovy
@@ -16,6 +16,7 @@
 package org.asciidoctor.gradle.internal
 
 import groovy.transform.CompileStatic
+import org.gradle.api.logging.LogLevel
 import org.ysb33r.grolifant.api.OperatingSystem
 
 @CompileStatic
@@ -51,4 +52,24 @@ class AsciidoctorUtils {
         base.toPath().relativize(target.toPath()).toFile().toString()
     }
 
+    /** Determines an executor logging level from the current Gradle logging level
+     *
+     * @param level
+     * @return
+     */
+    static ExecutorLogLevel getExecutorLogLevel(LogLevel level) {
+        switch(level) {
+            case LogLevel.DEBUG:
+                return ExecutorLogLevel.DEBUG
+            case LogLevel.LIFECYCLE:
+            case LogLevel.WARN:
+                return ExecutorLogLevel.WARN
+            case LogLevel.INFO:
+                return ExecutorLogLevel.INFO
+            case LogLevel.QUIET:
+                return ExecutorLogLevel.QUIET
+            default:
+                return ExecutorLogLevel.ERROR
+        }
+    }
 }

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/internal/ExecutorConfiguration.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/internal/ExecutorConfiguration.groovy
@@ -48,6 +48,8 @@ class ExecutorConfiguration implements Serializable, Cloneable {
 
     List<Object> asciidoctorExtensions
 
+    ExecutorLogLevel executorLogLevel
+
     String toString() {
         """backend(s) = ${backendName}
 

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/internal/ExecutorLogLevel.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/internal/ExecutorLogLevel.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle.internal
+
+import groovy.transform.CompileStatic
+
+/** Log level that executor should operate at.
+ *
+ * @since 2.0
+ */
+@CompileStatic
+@SuppressWarnings('DuplicateNumberLiteral')
+enum ExecutorLogLevel implements Serializable {
+    DEBUG(0),
+    INFO(1),
+    WARN(2),
+    ERROR(3),
+    QUIET(4)
+
+    final int level
+
+    private ExecutorLogLevel(int level) {
+        this.level = level
+    }
+}

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -17,6 +17,7 @@ package org.asciidoctor.gradle.jvm
 
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
+import org.asciidoctor.gradle.internal.AsciidoctorUtils
 import org.asciidoctor.gradle.internal.ExecutorConfiguration
 import org.asciidoctor.gradle.internal.ExecutorConfigurationContainer
 import org.asciidoctor.gradle.remote.AsciidoctorJExecuter
@@ -48,7 +49,8 @@ import static groovy.lang.Closure.DELEGATE_FIRST
 import static org.gradle.workers.IsolationMode.CLASSLOADER
 import static org.gradle.workers.IsolationMode.PROCESS
 
-/**
+/** Base class for all AsciidoctorJ tasks.
+ *
  * @since 2.0.0
  * @author Schalk W. Cronjé
  */
@@ -69,7 +71,8 @@ class AbstractAsciidoctorTask extends DefaultTask {
     private final AsciidoctorJExtension asciidoctorj
     private final WorkerExecutor worker
     private final List<Object> asciidocConfigurations = []
-    private final org.ysb33r.grolifant.api.JavaForkOptions javaForkOptions = new org.ysb33r.grolifant.api.JavaForkOptions()
+    private
+    final org.ysb33r.grolifant.api.JavaForkOptions javaForkOptions = new org.ysb33r.grolifant.api.JavaForkOptions()
 
     private Object baseDir
     private Object srcDir
@@ -81,7 +84,6 @@ class AbstractAsciidoctorTask extends DefaultTask {
     private List<String> copyResourcesForBackends
     private boolean withIntermediateWorkDir = false
 
-
     /** Logs documents as they are converted
      *
      */
@@ -91,12 +93,10 @@ class AbstractAsciidoctorTask extends DefaultTask {
     /** Run Asciidoctor conversions in or out of process
      *
      * Valid options are {@link #IN_PROCESS}, {@link #OUT_OF_PROCESS} and {@link #JAVA_EXEC}.
-     * {@code JAVA_EXEC} should only be used as a last resort ans it runs less effective than the
-     * other options. It does provide completion isolation and is a workaround when Gradle's
-     * logic for classpath isolation is not enough.
+     *
      */
     @Internal
-    ProcessMode inProcess = IN_PROCESS
+    ProcessMode inProcess = JAVA_EXEC
 
     /** Set the mode for running conversions sequential or in parallel.
      * For instance a task that has multiple backends can have the
@@ -113,7 +113,7 @@ class AbstractAsciidoctorTask extends DefaultTask {
      *
      * Default is parallel.
      *
-     * WHen {@link #inProcess} {@code ==} {@link JAVA_EXEC} this option is ignored.
+     * WHen {@link #inProcess} {@code ==} {@link #JAVA_EXEC} this option is ignored.
      */
     @Internal
     boolean parallelMode = true
@@ -164,7 +164,7 @@ class AbstractAsciidoctorTask extends DefaultTask {
      * @param configurator Closure that configures a {@link org.ysb33r.grolifant.api.JavaForkOptions} instance.
      */
     void forkOptions(@DelegatesTo(org.ysb33r.grolifant.api.JavaForkOptions) Closure configurator) {
-        Closure cfg = (Closure)(configurator.clone())
+        Closure cfg = (Closure) (configurator.clone())
         cfg.delegate = this.javaForkOptions
         cfg.resolveStrategy = DELEGATE_FIRST
         cfg.call()
@@ -506,12 +506,11 @@ class AbstractAsciidoctorTask extends DefaultTask {
      *   constructor of the subclass.
      */
     protected AbstractAsciidoctorTask(WorkerExecutor we) {
-        worker = we
-        asciidoctorj = extensions.create(AsciidoctorJExtension.NAME, AsciidoctorJExtension, this)
+        this.worker = we
+        this.asciidoctorj = extensions.create(AsciidoctorJExtension.NAME, AsciidoctorJExtension, this)
 
         addInputProperty 'required-ruby-modules', { asciidoctorj.requires }
         addInputProperty 'gemPath', { asciidoctorj.asGemPath() }
-        addInputProperty 'verboseMode', { asciidoctorj.verboseMode }
         addInputProperty 'trackBaseDir', { getBaseDir().absolutePath }
 
         inputs.files { asciidoctorj.gemPaths }
@@ -564,6 +563,7 @@ class AbstractAsciidoctorTask extends DefaultTask {
             asciidoctorExtensions: (asciidoctorJExtensions.findAll { !(it instanceof Dependency) }),
             requires: requires,
             copyResources: this.copyResourcesForBackends != null && (this.copyResourcesForBackends.empty || backendName in this.copyResourcesForBackends),
+            executorLogLevel: AsciidoctorUtils.getExecutorLogLevel(asciidoctorj.logLevel),
             safeModeLevel: asciidoctorj.safeMode.level
         )
     }
@@ -694,17 +694,7 @@ class AbstractAsciidoctorTask extends DefaultTask {
      */
     @Internal
     protected Set<String> getRequires() {
-        if (asciidoctorj.verboseMode) {
-            File verbose = verboseScriptModule
-            verbose.parentFile.mkdirs()
-            verbose.text = '$VERBOSE = true'
-            Set<String> newRequires = []
-            newRequires.addAll(asciidoctorj.requires)
-            newRequires.add(project.file(verbose).absolutePath)
-            newRequires
-        } else {
-            asciidoctorj.requires
-        }
+        asciidoctorj.requires
     }
 
     /** Selects a final process mode.
@@ -764,10 +754,6 @@ class AbstractAsciidoctorTask extends DefaultTask {
         if (sourceRoot != baseRoot || outputRoot != baseRoot) {
             throw new AsciidoctorExecutionException('sourceDir, outputDir and baseDir needs to have the same root filesystem for AsciidoctorJ to function correctly. This is typically caused on Winwdows where everything is not on the same drive letter.')
         }
-    }
-
-    private File getVerboseScriptModule() {
-        project.file("${project.buildDir}/tmp/${FileUtils.toSafeFileName(name)}/${FileUtils.toSafeFileName(name)}-verbose-mode.rb")
     }
 
     private String getGemPath() {

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJExtension.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJExtension.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencyResolveDetails
 import org.gradle.api.artifacts.ResolutionStrategy
 import org.gradle.api.file.FileCollection
+import org.gradle.api.logging.LogLevel
 import org.ysb33r.grolifant.api.AbstractCombinedProjectTaskExtension
 import org.ysb33r.grolifant.api.OperatingSystem
 
@@ -90,7 +91,7 @@ class AsciidoctorJExtension extends AbstractCombinedProjectTaskExtension {
     private boolean onlyTaskExtensions = false
     private boolean onlyTaskGems = false
 
-    private Boolean verboseMode
+    private LogLevel logLevel
 
     private SafeMode safeMode
 
@@ -106,7 +107,6 @@ class AsciidoctorJExtension extends AbstractCombinedProjectTaskExtension {
         this.attributes['gradle-project-version'] = { project.version ?: '' }
 
         this.safeMode = SafeMode.SAFE
-        this.verboseMode = false
         this.groovyDslVersion = Optional.empty()
     }
 
@@ -131,7 +131,7 @@ class AsciidoctorJExtension extends AbstractCombinedProjectTaskExtension {
 
     /** Set a new version to use.
      *
-     * @param v New version to be used. Can be of anything that be be resolved by {@link stringize ( Object o }
+     * @param v New version to be used. Can be of anything that be be resolved by {@link stringize(Object o)}
      */
     void setVersion(Object v) {
         this.version = v
@@ -563,16 +563,33 @@ class AsciidoctorJExtension extends AbstractCombinedProjectTaskExtension {
         onlyTaskExtensions = true
     }
 
-    void setVerboseMode(boolean mode) {
-        this.verboseMode = mode
+
+    /** The level at which the AsciidoctorJ process should be logging.
+     *
+     * @return The currently configured log level. By default this is {@code project.logging.level}.
+     */
+    LogLevel getLogLevel() {
+        if(task) {
+            this.logLevel == null ? extFromProject.logLevel : this.logLevel
+        } else {
+            this.logLevel ?: project.logging.level
+        }
     }
 
-    boolean getVerboseMode() {
-        if (task) {
-            this.verboseMode == null ? extFromProject.verboseMode : this.verboseMode
-        } else {
-            this.verboseMode
-        }
+    /** Set the level at which the AsciidoctorJ process should be logging.
+     *
+     * @param logLevel LogLevel to use
+     */
+    void setLogLevel(LogLevel logLevel) {
+        this.logLevel = logLevel
+    }
+
+    /** Set the level at which the AsciidoctorJ process should be logging.
+     *
+     * @param logLevel LogLevel to use
+     */
+    void setLogLevel(String logLevel) {
+        this.logLevel = LogLevel.valueOf(logLevel.toUpperCase())
     }
 
     /** Clears the current list of resolution strategies.

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/remote/ExecutorBase.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/remote/ExecutorBase.groovy
@@ -20,8 +20,6 @@ import org.asciidoctor.Options
 import org.asciidoctor.gradle.internal.ExecutorConfiguration
 import org.asciidoctor.gradle.internal.ExecutorConfigurationContainer
 
-import static groovy.lang.Closure.DELEGATE_ONLY
-
 /** Base class for building claspath-isolated executors for Asciidoctor.
  *
  * @since 2.0.0
@@ -90,8 +88,8 @@ class ExecutorBase {
             switch (it) {
                 case Closure:
                     Closure rehydrated = ((Closure) it).rehydrate(registry, null, null)
-                    rehydrated.resolveStrategy = DELEGATE_ONLY
-                    (Object)rehydrated
+                    rehydrated.resolveStrategy = Closure.DELEGATE_ONLY
+                    (Object) rehydrated
                     break
                 default:
                     it

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/remote/LogSeverityMapper.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/remote/LogSeverityMapper.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle.remote
+
+import groovy.transform.CompileStatic
+import org.asciidoctor.gradle.internal.ExecutorLogLevel
+import org.asciidoctor.log.Severity
+
+@java.lang.SuppressWarnings('NoWildcardImports')
+import static org.asciidoctor.log.Severity.*
+
+/** Maps from Asciidoctor severities to {@link ExecutorLogLevel} levels.
+ *
+ * @since 2.0
+ */
+@CompileStatic
+class LogSeverityMapper {
+
+    static ExecutorLogLevel getSeverity(Severity sev) {
+        switch(sev) {
+            case DEBUG:
+                ExecutorLogLevel.DEBUG
+                break
+            case INFO:
+                ExecutorLogLevel.INFO
+                break
+            case WARN:
+                ExecutorLogLevel.WARN
+                break
+            case FATAL:
+                ExecutorLogLevel.QUIET
+                break
+            case ERROR:
+            default:
+                ExecutorLogLevel.ERROR
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ bintray_dryRun = false
 cglibVersion           = 3.2.6
 jsoupVersion           = 1.11.2
 spockVersion           = 1.1-groovy-2.4
-grolifantVersion       = 0.6
+grolifantVersion       = 0.7

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 2.0.0-alpha.1-SNAPSHOT
+version = 2.0.0-alpha.1
 group = org.asciidoctor
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/gradle/ci.gradle
+++ b/gradle/ci.gradle
@@ -1,17 +1,20 @@
 apply plugin : 'org.ysb33r.cloudci'
 
 cloudci {
-    travisci {
+    any {
         ext {
             logBeforeTest = { desc ->
                 project.logger.lifecycle "Running: ${desc.name} (${desc.className})"
             }
-            logAfterTest = { testTracker, desc, result ->
+            logAfterTest = { testTracker, descriptor, result ->
+                String key = "${descriptor.name} (${descriptor.className})"
+                long time = result.endTime - result.startTime
                 if(result.resultType == org.gradle.api.tasks.testing.TestResult.ResultType.FAILURE) {
-                    String key = "${descriptor.name} (${descriptor.className})"
-                    project.logger.lifecycle "FAILED: ${key}",
+                    project.logger.lifecycle "FAILED (${time}s): ${key}",
                         result.exceptions,
                         testTracker.containsKey(key) ? testTracker[key] : ''
+                } else {
+                    project.logger.lifecycle "Completed (${time}s): ${key}"
                 }
             }
 

--- a/gradle/ci.gradle
+++ b/gradle/ci.gradle
@@ -1,7 +1,6 @@
 apply plugin : 'org.ysb33r.cloudci'
 
-cloudci {
-    any {
+cloudci.any {
         ext {
             logBeforeTest = { desc ->
                 project.logger.lifecycle "Running: ${desc.name} (${desc.className})"
@@ -40,4 +39,4 @@ cloudci {
             }
         }
     }
-}
+

--- a/gradle/compatibility-tests.gradle
+++ b/gradle/compatibility-tests.gradle
@@ -2,6 +2,8 @@ apply plugin : 'org.ysb33r.gradletest'
 
 gradleTest {
 
+    versions '4.8.1'
+
     if(JavaVersion.current().java10) {
         versions '4.7'
     } else {

--- a/testfixtures/jvm/src/main/groovy/org/asciidoctor/gradle/testfixtures/jvm/generators/VersionProcessModeGenerator.groovy
+++ b/testfixtures/jvm/src/main/groovy/org/asciidoctor/gradle/testfixtures/jvm/generators/VersionProcessModeGenerator.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle.testfixtures.jvm.generators
+
+import groovy.transform.CompileStatic
+import org.asciidoctor.gradle.testfixtures.jvm.AsciidoctorjTestVersions
+
+/** A test fixture generator class for ASciidoctorJ version & process mode.
+ *
+ * @since 2.0
+ */
+@CompileStatic
+class VersionProcessModeGenerator {
+
+    static final String JAVA_EXEC = 'JAVA_EXEC'
+    static final String IN_PROCESS = 'IN_PROCESS'
+    static final String OUT_OF_PROCESS = 'OUT_OF_PROCESS'
+
+    @SuppressWarnings('ClassName')
+    static class VersionProcess {
+        String version
+        String processMode
+
+        @Override
+        String toString() {
+            "Asciidoctorj: ${version}, mode: ${processMode}"
+        }
+
+        static VersionProcess of(final String v, final String p) {
+            new VersionProcess(version: v, processMode: p)
+        }
+    }
+
+    static List<VersionProcess> get() {
+        if (System.getenv('APPVEYOR')) {
+            [AsciidoctorjTestVersions.SERIES_15, AsciidoctorjTestVersions.SERIES_16].collect {
+                VersionProcess.of(it, JAVA_EXEC)
+            }
+        } else {
+            [AsciidoctorjTestVersions.SERIES_15, AsciidoctorjTestVersions.SERIES_16].collect { it ->
+                [
+                    VersionProcess.of(it, JAVA_EXEC),
+                    VersionProcess.of(it, IN_PROCESS),
+                    VersionProcess.of(it, OUT_OF_PROCESS)
+                ]
+            }.flatten() as List<VersionProcess>
+
+        }
+    }
+
+    static List<VersionProcess> getRandom() {
+        List<VersionProcess> vp = get()
+        Collections.shuffle(vp)
+        vp
+    }
+}


### PR DESCRIPTION
Also optimised test approach:

- Do not allow extension tests to take more than 3 min each.
- Use specific JRuby versions for 1.6.x testing.
- Update the test listener for CI to monitor output.
- Add a generator to testfixtures for providing AJ version + process mode
- When running on Appveyor only use JAVA_EXEC.