### PR TITLE
Rework publishing to the Gradle Plugin Portal

### DIFF
--- a/asciidoctor-gradle-base/build.gradle
+++ b/asciidoctor-gradle-base/build.gradle
@@ -15,12 +15,9 @@
  * limitations under the License.
  */
 
-gradlePlugin {
-    plugins {
-        asciidoctorBasePlugin {
-            id = 'org.asciidoctor.org.asciidoctor.base'
-            implementationClass = 'org.asciidoctor.gradle.base.AsciidoctorBasePlugin'
-            description = 'Base plugin for AsciidoctorJ & AscidoctorJS plugins'
-        }
-    }
-}
+configurePlugin 'org.asciidoctor.base',
+    'Asciidoctor Base Plugin',
+    'Base plugin for all asciidoctor document conversion plugins (AsciidoctorJ & AsciidoctorJS)',
+    [ ]
+
+

--- a/asciidoctor-gradle-jvm-epub/build.gradle
+++ b/asciidoctor-gradle-jvm-epub/build.gradle
@@ -12,12 +12,8 @@ intTest {
     systemProperties TEST_PROJECTS_DIR : file('src/intTest/projects')
 }
 
-gradlePlugin {
-    plugins {
-        AsciidoctorEpubPlugin {
-            id = 'org.asciidoctor.org.asciidoctor.jvm.epub'
-            implementationClass = 'org.asciidoctor.gradle.jvm.epub.AsciidoctorJEpubPlugin'
-            description = "Converts Asciidoctor documents to EPUB3/KF8 using AsciidoctorJ${pluginExtraText}"
-        }
-    }
-}
+configurePlugin 'org.asciidoctor.jvm.epub',
+    'AsciidoctorJ EPUB Plugin',
+    'Asciidoctor task for creating EPUB3 & KF8 documents',
+    [ 'asciidoctorj', 'epub', 'epub3', 'kf8']
+

--- a/asciidoctor-gradle-jvm/build.gradle
+++ b/asciidoctor-gradle-jvm/build.gradle
@@ -46,30 +46,25 @@ dependencies {
     }
 }
 
-gradlePlugin {
-    plugins {
-        asciidoctorBasePlugin {
-            id = 'org.asciidoctor.org.asciidoctor.jvm.base'
-            implementationClass = 'org.asciidoctor.gradle.jvm.AsciidoctorJBasePlugin'
-            description = "Base plugin for running AsciidoctorJ${pluginExtraText}"
-        }
-        asciidoctorCompatibilityPlugin {
-            id = 'org.asciidoctor.convert'
-            implementationClass = 'org.asciidoctor.gradle.AsciidoctorCompatibilityPlugin'
-            description = "Compatibility AsciidoctorJ plugin for those upgrading from 1.5.x${pluginExtraText}"
-        }
-        asciidoctorPlugin {
-            id = 'org.asciidoctor.org.asciidoctor.jvm.convert'
-            implementationClass = 'org.asciidoctor.gradle.jvm.AsciidoctorJPlugin'
-            description = "Converts Asciidoctor documents using AsciidoctorJ${pluginExtraText}"
-        }
-        asciidoctorPdfPlugin {
-            id = 'org.asciidoctor.org.asciidoctor.jvm.pdf'
-            implementationClass = 'org.asciidoctor.gradle.jvm.AsciidoctorJPdfPlugin'
-            description = "Converts Asciidoctor documents to PDF using AsciidoctorJ${pluginExtraText}"
-        }
-    }
-}
+configurePlugin 'org.asciidoctor.jvm.base',
+    'AsciidoctorJ Base Plugin',
+    'Base plugin for all AsciidoctorJ tasks & extensions. Provides the asciidoctorj project extension.',
+    [ 'asciidoctorj' ]
+
+configurePlugin 'org.asciidoctor.convert',
+    'AsciidoctorJ Compatibility Plugin',
+    'Compatibility AsciidoctorJ plugin for those upgrading from 1.5.x',
+    [ 'asciidoctorj', 'html5', 'docbook', 'pdf', 'epub3' ]
+
+configurePlugin 'org.asciidoctor.jvm.convert',
+    'AsciidoctorJ General Purpose Document Conversion Plugin',
+    'Provides asciidoctor task and conventions',
+    [ 'asciidoctorj', 'html5', 'docbook' ]
+
+configurePlugin 'org.asciidoctor.jvm.pdf',
+    'AsciidoctorJ PDF Conversion Plugin',
+    'Simplifies convesion of asciidoc documetns to PDF',
+    [ 'asciidoctorj', 'pdf' ]
 
 intTest {
     systemProperties TEST_PROJECTS_DIR: file('src/intTest/projects')

--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,8 @@ import java.text.SimpleDateFormat
 
 apply plugin: 'net.nemerosa.versioning'
 
-Date buildTimeAndDate = new Date()
 ext {
+    buildTimeAndDate = new Date()
     buildDate = new SimpleDateFormat('yyyy-MM-dd').format(buildTimeAndDate)
     buildTime = new SimpleDateFormat('HH:mm:ss.SSSZ').format(buildTimeAndDate)
     buildRevision = versioning.info.commit
@@ -62,10 +62,7 @@ subprojects {
         if (!project.name.startsWith('testfixture')) {
             apply plugin: 'maven-publish'
             apply plugin: 'jacoco'
-            apply plugin: 'java-gradle-plugin'
-            // apply plugin: 'com.jfrog.bintray'
             apply plugin: 'com.github.ben-manes.versions'
-            // apply plugin: 'com.gradle.plugin-publish'
             apply plugin: 'com.github.kt3k.coveralls'
             apply plugin: 'net.ossindex.audit'
             apply plugin: 'org.kordamp.jdeps'
@@ -87,8 +84,6 @@ subprojects {
                 apply from: "${rootProject.projectDir}/gradle/jruby-versions.gradle"
                 apply from: "${rootProject.projectDir}/gradle/ci.gradle"
             }
-
-            // task publishRelease(dependsOn: [bintrayUpload, publishPlugins]) {}
 
             dependencyUpdates.resolutionStrategy = {
                 componentSelection { rules ->

--- a/gradle/asciidoctorj-versions.gradle
+++ b/gradle/asciidoctorj-versions.gradle
@@ -1,8 +1,4 @@
 ext {
-    pluginExtraText = (version.contains('-alpha') || version.contains('-beta')) ?
-        " (If you need a production-ready version of the AsciidoctorJ plugin for Gradle use a 1.5.x release of 'org.asciidoctor.convert' instead)"
-        : ''
-
     extensionFileContent = file("${project(':asciidoctor-gradle-jvm').projectDir}/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJExtension.groovy").readLines()
     asciidoctorjFixtureFileContent = file("${project(':testfixtures-jvm').projectDir}/src/main/groovy/org/asciidoctor/gradle/testfixtures/jvm/AsciidoctorjTestVersions.groovy").readLines()
 

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -14,6 +14,63 @@
  * limitations under the License.
  */
 
+apply plugin: 'java-gradle-plugin'
+apply plugin: 'com.gradle.plugin-publish'
+//apply plugin: 'com.jfrog.bintray'
+
+ext {
+    pluginIdPrefix = 'org.asciidoctor'
+
+    pluginExtraText = (version.contains('-alpha') || version.contains('-beta')) ?
+        " (If you need a production-ready version of the AsciidoctorJ plugin for Gradle use a 1.5.x release of 'org.asciidoctor.convert' instead)"
+        : ''
+
+
+    configurePlugin = {  String providedId, String providedDisplayName, String providedDescription, List<String> providedTags ->
+        final String providedName = providedId.replaceAll(~/\./,'')
+        final File props = file("src/main/resources/META-INF/gradle-plugins/${providedId}.properties")
+        if(!props.exists()) {
+            throw new GradleException( "${props} does not exist")
+        }
+        String className
+        for( String line : props.readLines() ) {
+            def match = line =~ /^implementation-class\s*=\s*(.+?)$/
+
+            if(match.matches()) {
+                className = match[0][1]
+                break
+            }
+        }
+
+        if(className == null) {
+            throw new GradleException("${props} does not contain implemention-class")
+        }
+
+        gradlePlugin {
+            plugins {
+                "${providedName}Plugin" {
+                    id = providedId
+                    implementationClass = className
+                }
+            }
+        }
+
+        pluginBundle {
+            plugins {
+                "${providedName}Plugin" {
+                    id = providedId
+                    displayName = providedDisplayName
+                    description = "${providedDescription}${pluginExtraText}"
+                    tags = (['asciidoctor'] + providedTags)
+                }
+            }
+        }
+
+//        bintray.pkg.labels = (['asciidoctor', 'gradle', 'plugin'] + providedTags)
+//        bintray.pkg.version.attributes = ['gradle-plugin': "${providedId}:org.asciidoctor:asciidoctor-gradle-plugin"]
+    }
+}
+
 jar {
     manifest {
         attributes(
@@ -37,64 +94,67 @@ jar {
     }
 }
 
-def pomConfig = {
-    name project.name
-    description project.project_description
-    url project.project_website
-    inceptionYear '2013'
-    licenses {
-        license([:]) {
-            name 'The Apache Software License, Version 2.0'
-            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-            distribution 'repo'
-        }
-    }
-    scm {
-        url project.project_vcs
-    }
-    developers {
-        developer {
-            id 'mojavelinux'
-            name 'Dan Allen'
-            roles {
-                role 'Asciidoctor Founder and Benevolent Dictator'
-                role 'Open Source Hero'
+ext {
+    pomConfig = {
+        name project.name
+        description project.project_description
+        url project.project_website
+        inceptionYear '2013'
+        licenses {
+            license([:]) {
+                name 'The Apache Software License, Version 2.0'
+                url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                distribution 'repo'
             }
         }
-        [
-            aalmiray: 'Andres Almiray',
-            noamt   : 'Noam Tenne',
-            bmuschko: 'Benjamin Muschko'
-        ].each { devId, devName ->
+        scm {
+            url project.project_vcs
+        }
+        developers {
             developer {
-                id devId
-                name devName
+                id 'mojavelinux'
+                name 'Dan Allen'
                 roles {
-                    role 'Developer'
+                    role 'Asciidoctor Founder and Benevolent Dictator'
+                    role 'Open Source Hero'
+                }
+            }
+            [
+                aalmiray: 'Andres Almiray',
+                noamt   : 'Noam Tenne',
+                bmuschko: 'Benjamin Muschko',
+                ysb33r:   'Schalk W. Cronjé'
+            ].each { devId, devName ->
+                developer {
+                    id devId
+                    name devName
+                    roles {
+                        role 'Developer'
+                    }
                 }
             }
         }
-    }
-    contributors {
-        [
-            tombujok   : 'Tom Bujok',
-            jlupi      : 'Lukasz Pielak',
-            dvyazelenko: 'Dmitri Vyazelenko',
-            rwinch     : 'Rob Winch',
-            Skyr       : 'Stefan Schlott',
-            sclassen   : 'Stephan Classen',
-            McPringle  : 'Marcus Fihlon',
-            msgilligan : 'Sean Gilligan',
-            afolmert   : 'Adam Folmert',
-            mrhaki     : 'Hubert Klein Ikkink',
-            bobbytank42: 'Robert Panzer',
-            oti        : 'Otmar Humbel',
-            anschmi    : 'Andreas Schmidt'
-        ].each { devId, devName ->
-            contributor {
-                name devName
-                roles {
-                    role 'contributor'
+        contributors {
+            [
+                tombujok   : 'Tom Bujok',
+                jlupi      : 'Lukasz Pielak',
+                dvyazelenko: 'Dmitri Vyazelenko',
+                rwinch     : 'Rob Winch',
+                Skyr       : 'Stefan Schlott',
+                sclassen   : 'Stephan Classen',
+                McPringle  : 'Marcus Fihlon',
+                msgilligan : 'Sean Gilligan',
+                afolmert   : 'Adam Folmert',
+                mrhaki     : 'Hubert Klein Ikkink',
+                bobbytank42: 'Robert Panzer',
+                oti        : 'Otmar Humbel',
+                anschmi    : 'Andreas Schmidt'
+            ].each { devId, devName ->
+                contributor {
+                    name devName
+                    roles {
+                        role 'contributor'
+                    }
                 }
             }
         }
@@ -116,41 +176,33 @@ publishing {
     }
 }
 
-/*
-bintray {
-    user = bintrayUsername
-    key = bintrayKey
-    publications = ['mavenJava']
-    dryRun = bintrayDryRun.toBoolean()
-    pkg {
-        userOrg = bintrayOrg
-        repo = bintrayRepo
-        name = project.name
-        desc = project.project_description
-        licenses = ['Apache-2.0']
-        labels = ['asciidoctor', 'gradle', 'plugin']
-        websiteUrl = project.project_website
-        issueTrackerUrl = project.project_issues
-        vcsUrl = project.project_vcs
-        publicDownloadNumbers = true
-        version {
-            attributes = ['gradle-plugin': 'org.asciidoctor.convert:org.asciidoctor:asciidoctor-gradle-plugin']
-        }
-    }
-}
+//bintray {
+//    user = bintrayUsername
+//    key = bintrayKey
+//    publications = ['mavenJava']
+//    dryRun = bintrayDryRun.toBoolean()
+//    pkg {
+//        userOrg = bintrayOrg
+//        repo = bintrayRepo
+//        name = project.name
+//        desc = project.project_description
+//        licenses = ['Apache-2.0']
+////        labels = ['asciidoctor', 'gradle', 'plugin']
+//        websiteUrl = project.project_website
+//        issueTrackerUrl = project.project_issues
+//        vcsUrl = project.project_vcs
+//        publicDownloadNumbers = true
+////        version {
+////            attributes = ['gradle-plugin': 'org.asciidoctor.convert:org.asciidoctor:asciidoctor-gradle-plugin']
+////        }
+//    }
+//}
 
 pluginBundle {
     website = project.project_website
     vcsUrl = project.project_vcs
     description = project.project_description
-    tags = ['asciidoctor', 'gradle', 'plugin']
-
-    plugins {
-        asciidoctorPlugin {
-            id = project_pluginId
-            displayName = 'Asciidoctor Gradle Plugin'
-        }
-    }
+    tags = ['asciidoctor']
 
     mavenCoordinates {
         groupId = project.group
@@ -158,4 +210,6 @@ pluginBundle {
         version = project.version
     }
 }
-*/
+
+// task publishRelease(dependsOn: [bintrayUpload, publishPlugins]) {}
+

--- a/kindlegen-gradle/build.gradle
+++ b/kindlegen-gradle/build.gradle
@@ -16,3 +16,8 @@ test {
     systemProperties OFFLINE_REPO: offlineRepoRoot.absolutePath
 }
 
+configurePlugin 'org.asciidoctor.kindlegen.base',
+    'Kindlegen Gradle Base Plugin',
+    'Provides kindlegen extension and removes need to install kindlegen manually',
+    [ 'kindlegen', 'epub', 'epub3', 'kf8']
+


### PR DESCRIPTION
Add extension mentohd to make it easier to configure both `gradlePlugins` and `publishPlugins` in one go.

Did not enable Bintray yet, as this is a legacy way of publishing plugins and requires setting of a version attribute. The problem with this situation is that it assumes only one plugin per jar, which is not the case for plugins nowadsys.