### PR TITLE
revert projectdir and rootdir attribute names back to 1.5.x pattern

### DIFF
--- a/src/main/groovy/org/asciidoctor/gradle/backported/AsciidoctorJavaExec.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/backported/AsciidoctorJavaExec.groovy
@@ -134,8 +134,8 @@ class AsciidoctorJavaExec {
             // Asciidoctor cannot handle absolute paths in Windows properly
             Map<String, Object> newAttrs = [:]
             newAttrs.putAll(attributes)
-            newAttrs['gradle-projectdir'] = getRelativePath(projectDir, file.parentFile)
-            newAttrs['gradle-rootdir'] = getRelativePath(rootDir, file.parentFile)
+            newAttrs.projectdir = getRelativePath(projectDir, file.parentFile)
+            newAttrs.rootdir = getRelativePath(rootDir, file.parentFile)
             mergedOptions[Options.ATTRIBUTES] = newAttrs
         }
 


### PR DESCRIPTION
I'm not sure if this change was intentional, but with the backport commit, these attribute names were changed. I think this change should be left for 2.0 where it has been documented.