### PR TITLE
Legacy attributes deprecation message triggers selectively (#270)

### DIFF
--- a/src/intTest/projects/normal/src/docs/asciidoc/sample.asciidoc
+++ b/src/intTest/projects/normal/src/docs/asciidoc/sample.asciidoc
@@ -24,3 +24,5 @@ NOTE: This is test, only a test.
 * Item 2
 * Item 3
 
+A legacy {projectdir} attribute.
+

--- a/src/main/groovy/org/asciidoctor/gradle/backported/AsciidoctorJavaExec.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/backported/AsciidoctorJavaExec.groovy
@@ -139,7 +139,6 @@ class AsciidoctorJavaExec {
 
             newAttrs['gradle-projectdir'] = getRelativePath(projectDir, file.parentFile)
             newAttrs['gradle-rootdir'] = getRelativePath(rootDir, file.parentFile)
-            println 'Implicit attributes projectdir and rootdir are deprecated and will no longer be set in 2.0. Please migrate your documents to use gradle-projectdir and gradle-rootdir instead.'
             mergedOptions[Options.ATTRIBUTES] = newAttrs
         }
 


### PR DESCRIPTION
Potential source documetns are now scanned for the usage of
projectdir and rootdir. A warning message will only be printed when found.

If the Gradle vesion is < 4.5 the list of files will always be printed.
In later versions the additional files will only be printed if the
`--warning-mode=all` is set on the command line.