### PR TITLE
Release 1.5.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 1.5.10-SNAPSHOT
+version = 1.5.10
 group = org.asciidoctor
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
@@ -14,7 +14,7 @@ bintray_org    = asciidoctor
 bintray_repo   = maven
 bintray_dryRun = false
 
-asciidoctorjVersion    = 1.6.0
+asciidoctorjVersion    = 1.6.1
 asciidoctorjDslVersion = 1.0.0.Alpha3
 cglibVersion           = 3.2.8
 jsoupVersion           = 1.11.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ bintray_org    = asciidoctor
 bintray_repo   = maven
 bintray_dryRun = false
 
-asciidoctorjVersion    = 1.5.7
+asciidoctorjVersion    = 1.6.0
 asciidoctorjDslVersion = 1.0.0.Alpha3
 cglibVersion           = 3.2.8
 jsoupVersion           = 1.11.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 1.5.9.3-SNAPSHOT
+version = 1.5.10-SNAPSHOT
 group = org.asciidoctor
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ asciidoctorjDslVersion = 1.0.0.Alpha3
 cglibVersion           = 3.2.8
 jsoupVersion           = 1.11.3
 spockVersion           = 1.1-groovy-2.4
-grolifantVersion       = 0.9
+grolifantVersion       = 0.10

--- a/src/intTest/groovy/org/asciidoctor/gradle/AsciidoctorFunctionalSpec.groovy
+++ b/src/intTest/groovy/org/asciidoctor/gradle/AsciidoctorFunctionalSpec.groovy
@@ -123,7 +123,7 @@ class AsciidoctorFunctionalSpec extends Specification {
         then:
         result.task(":asciidoctor").outcome == TaskOutcome.SUCCESS
         new File(buildDir, "asciidoc/html5/sample.html").exists()
-        output.contains('It seems that you may be using implicit attributes ')
+        output.contains('It seems that you may be using one or more implicit attributes')
         output.contains('sample.asciidoc')
     }
 

--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorExtension.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorExtension.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.Project
  * @author Andres Almiray
  */
 class AsciidoctorExtension {
-    String version = '1.5.8.1'
+    String version = '1.6.0'
 
     String groovyDslVersion = '1.0.0.Alpha3'
 

--- a/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
+++ b/src/main/groovy/org/asciidoctor/gradle/AsciidoctorTask.groovy
@@ -591,6 +591,15 @@ class AsciidoctorTask extends DefaultTask {
         File output = outputDir
 
         scanForLegacyAttributes()
+        Map finalAttributes = [
+            'gradle-project-group': project.group,
+            'gradle-project-name' : project.name,
+            'revnumber'           : project.version,
+            'project-version'     : project.version,
+            'project-group'       : project.group,
+            'project-name'        : project.name
+        ]
+        finalAttributes.putAll(attributes)
 
         ExecutorConfigurationContainer ecc = new ExecutorConfigurationContainer(activeBackends().collect { backend ->
             new ExecutorConfiguration(
@@ -608,7 +617,7 @@ class AsciidoctorTask extends DefaultTask {
                 safeModeLevel: resolveSafeModeLevel(options['safe'], 0),
                 requires: (Set) (getRequires() ?: []),
                 options: options,
-                attributes: attributes,
+                attributes: finalAttributes,
                 asciidoctorExtensions: dehydrateExtensions(getAsciidoctorExtensions())
             )
         })
@@ -754,11 +763,12 @@ class AsciidoctorTask extends DefaultTask {
 
         Set<File> hits = ft.files.findAll { File f ->
             String content = f.text
+            content.find( ~/\{(projectdir|rootdir|project-version|project-name|project-group)\}/ )
             content.contains('{projectdir}') || content.contains('{rootdir}')
         }
 
         if(!hits.empty) {
-            logger.warn 'It seems that you may be using implicit attributes `projectdir` and/or `rootdir` in your documents. These are deprecated and will no longer be set in 2.0. Please migrate your documents to use `gradle-projectdir` and `gradle-rootdir` instead.'
+            logger.warn 'It seems that you may be using one or more implicit attributes: `projectdir`, `rootdir`, `project-version`, `project-group`, `project.name` in your documents. These are deprecated and will no longer be set in 2.0. Please migrate your documents to use `gradle-projectdir`, `gradle-rootdir`, ``revnumber`, `gradle-project-version`, `gradle-project-name` respectively.'
 
             if(dumpLegacyFileList) {
                 File base = sourceDir


### PR DESCRIPTION
Restore usage of:
- project-version
- project-group
- project-name

Detect usage of all three and print a warning to rather use
- revnumber
- gradle-project-group
- gradle-project-name

All three the latter attributes will also be injected to aid migration
to 2.x releases.

Bump to use asciidoctorj 1.6.1.