### PR TITLE
gradle-relative-srcdir attribute

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -706,7 +706,7 @@ If you used `separateOutputDirs`, yout need to change that to `outputOptions.sep
 
 The base directory is now set to the directory of the root project. This may influence how your includes are processed. Either set `baseDir` to specific directory or or use the `includedir` which is automatically calculates to be the correct source directory.
 
-Gradle injected a number of attributes into the build. These names have now been changed to indicate that they are injected:
+Gradle injected a number of attributes into the build. Some of these names have been changed from 1.5/1.6. to indicate that they are injected:
 
 [cols="4*"]
 |===
@@ -716,6 +716,7 @@ Gradle injected a number of attributes into the build. These names have now been
 | `project-name` | `gradle-project-name` | Yes | The name of the current Gradle subproject. (Or the root project in case of a single project).
 | `project-group` | `gradle-project-group` | Yes | The project/artifact group if it is defined.
 | `project-version` | `revnumber` | Yes | The project version if it is defined.
+| - | `gradle-relative-srcdir` | No | The relative path from the parent of the current document that is being processed to the source document root. It is calcluated as moving from the current document towards the root. FOr instance `src/docs/asciidoc/subdir/sample.adoc` will set this attribute to `..` if `sourceDir` == `sr/docs/asciidoc`.
 |===
 
 Substituable attributes means that the build script author can change those attributes by setting them explicitly.

--- a/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskFunctionalSpec.groovy
+++ b/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskFunctionalSpec.groovy
@@ -156,6 +156,24 @@ class AsciidoctorTaskFunctionalSpec extends FunctionalSpecification {
         noExceptionThrown()
     }
 
+    @Issue('https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/292')
+    void 'Special gradle attributes are adapted per document'() {
+        given:
+        getBuildFile('''
+            asciidoctor {
+                sourceDir 'src/docs/asciidoc'
+            }
+        ''')
+
+        when:
+        getGradleRunner(DEFAULT_ARGS).build()
+        String sample2 = new File(testProjectDir.root, 'build/docs/asciidoc/subdir/sample2.html').text
+
+        then:
+        sample2.contains('gradle-relative-srcdir = [..]')
+
+    }
+
     File getBuildFile(String extraContent) {
         getJvmConvertGroovyBuildFile("""
 asciidoctorj {

--- a/asciidoctor-gradle-jvm/src/intTest/projects/normal/src/docs/asciidoc/subdir/sample2.ad
+++ b/asciidoctor-gradle-jvm/src/intTest/projects/normal/src/docs/asciidoc/subdir/sample2.ad
@@ -23,3 +23,12 @@ NOTE: This is test, only a test.
 * Item 2
 * Item 3
 
+== Attributes
+
+* gradle-projectdir = [{gradle-projectdir}]
+* gradle-rootdir = [{gradle-rootdir}]
+* gradle-relative-srcdir = [{gradle-relative-srcdir}]
+
+
+
+

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/remote/ExecutorBase.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/remote/ExecutorBase.groovy
@@ -91,6 +91,7 @@ abstract class ExecutorBase {
             newAttrs.putAll(attributes)
             newAttrs['gradle-projectdir'] = projectDir.absolutePath
             newAttrs['gradle-rootdir'] = rootDir.absolutePath
+            newAttrs['gradle-relative-srcdir'] = getRelativePath(sourceDir,file.parentFile) ?: '.'
 
             if(legacyAttributes) {
                 newAttrs['projectdir'] = newAttrs['gradle-projectdir']


### PR DESCRIPTION
Add this attribute to show the relative path of the containing
directory of the current document that is being processed, to
the source root (i.e. `asciidoctor.sourceDir`).