### PR TITLE
Do not add empty GEM paths for multiple backends (#324)

### DIFF
--- a/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskFunctionalSpec.groovy
+++ b/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskFunctionalSpec.groovy
@@ -174,6 +174,28 @@ class AsciidoctorTaskFunctionalSpec extends FunctionalSpecification {
 
     }
 
+    @Issue('https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/234')
+    void 'Run conversion with an unknown backend using JAVA_EXEC'() {
+        given:
+        getBuildFile('''
+        asciidoctor {
+            inProcess = JAVA_EXEC
+            outputOptions {
+                backends = ['html5', 'abc', 'xyz']
+            }
+            sourceDir 'src/docs/asciidoc'
+        }
+        ''')
+
+        when:
+        String result = getGradleRunner(DEFAULT_ARGS).buildAndFail().output
+
+        then:
+        result.contains("missing converter for backend 'abc'. Processing aborted")
+        result.contains('org.asciidoctor.internal.AsciidoctorCoreException: org.jruby.exceptions.NotImplementedError')
+        !result.contains('ArrayIndexOutOfBoundsException')
+    }
+
     File getBuildFile(String extraContent) {
         getJvmConvertGroovyBuildFile("""
 asciidoctorj {

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/remote/AsciidoctorJavaExec.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/remote/AsciidoctorJavaExec.groovy
@@ -75,7 +75,7 @@ class AsciidoctorJavaExec extends ExecutorBase {
     }
 
     private Asciidoctor getAsciidoctorInstance() {
-        String combinedGemPath = runConfigurations*.gemPath.join(File.pathSeparator)
+        String combinedGemPath = runConfigurations*.gemPath.findAll { it }.join(File.pathSeparator)
         if (combinedGemPath.empty || combinedGemPath == File.pathSeparator) {
             Asciidoctor.Factory.create()
         } else {

--- a/asciidoctor-gradle-jvm/src/remoteTest/groovy/org/asciidoctor/gradle/remote/internal/RemoteSpecification.groovy
+++ b/asciidoctor-gradle-jvm/src/remoteTest/groovy/org/asciidoctor/gradle/remote/internal/RemoteSpecification.groovy
@@ -32,6 +32,8 @@ class RemoteSpecification extends Specification {
     static final String OUTPUT_DOCBOOK = 'index.xml'
     static final String HTML = 'html5'
     static final String DOCBOOK = 'docbook'
+    static final String INVALID_1 = 'abc'
+    static final String INVALID_2 = 'def'
 
     @Rule
     TemporaryFolder testProjectDir


### PR DESCRIPTION
When running in JAVA_EXEC mode with three or more backends, but
no additional GEMs specified, the system failed with
`ArrayIndexOutOfBoundsException`. The reason was that `::` was
passed down to AsciidoctorJ as the GEM path. The solution is
not to add empty GEM paths to the GEM search path.