### PR TITLE
can't use asciidoctor as configuration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -827,15 +827,15 @@ is just like any other Java/Groovy project. You simply define a dependency using
 .build.gradle
 ----
 configurations {
-    asciidoctor
+    asciidoctorExt
 }
 
 dependencies {
-    asciidoctor 'com.acme:asciidoctor-extensions:x.y.z'
+    asciidoctorExt 'com.acme:asciidoctor-extensions:x.y.z'
 }
 
 asciidoctor {
-    configurations 'asciidoctor'
+    configurations 'asciidoctorExt'
 }
 ----
 


### PR DESCRIPTION
as asciidoctor exists as keyword you can't use asciidoctor as an identifier for configurations