### PR TITLE
Fixing --warning-mode command-line option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -762,7 +762,7 @@ viewDistance:: Number of slides away from the current that are visible.
 
 == Upgrading From Older Versions of Asciidoctor
 
-NOTE: To help with migration the old plugin will print a number of messages to help with a conversion. The amount of text is controlled via `--warnings-mode` in Gradle 4.5+. For Gradle 4.0-4.4 use `--info` to get the full list of recommendations. Use of `--warnings-mode=none`  (Gradle 4.5+) or `--quiet` (Gradle 4.0-4.4) will produce migration information.
+NOTE: To help with migration the old plugin will print a number of messages to help with a conversion. The amount of text is controlled via `--warning-mode` in Gradle 4.5+. For Gradle 4.0-4.4 use `--info` to get the full list of recommendations. Use of `--warning-mode=none`  (Gradle 4.5+) or `--quiet` (Gradle 4.0-4.4) will produce migration information.
 
 Firstly replace plugin `org.asciidoctor.convert` with `org.asciidoctor.jvm.convert`.
 

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/compat/AsciidoctorCompatibilityPlugin.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/compat/AsciidoctorCompatibilityPlugin.groovy
@@ -154,7 +154,7 @@ class AsciidoctorCompatibilityPlugin implements Plugin<Project> {
                     case 'none':
                         break
                     default:
-                        project.logger.lifecycle 'You are using one or more deprecated Asciidoctor task or plugins. To help with migration run with --warnings=all'
+                        project.logger.lifecycle 'You are using one or more deprecated Asciidoctor task or plugins. To help with migration run with --warning-mode=all'
                 }
             } else {
                 if (project.gradle.startParameter.logLevel != LogLevel.QUIET) {


### PR DESCRIPTION
The plugin is sometimes displaying this hint line:
```
You are using one or more deprecated Asciidoctor task or plugins. To help with migration run with --warnings=all
```

But when you run `./gradlew asciidoctor --warnings=all`

You get:

```
> Configure project :
You are using one or more deprecated Asciidoctor task or plugins. To help with migration run with --warnings=all

FAILURE: Build failed with an exception.

* What went wrong:
Problem configuring task :asciidoctor from command line.
> Unknown command-line option '--warnings'.

* Try:
Run gradlew help --task :asciidoctor to get task usage details. Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org
```

The correct call is `./gradlew asciidoctor --warning-mode=all`.

---

This PR is fixing the hint and the documentation. 
There is no such thing as `--warnings` or `--warnings-mode`.