### PR TITLE
Fix compatibility with script plugins

### DIFF
--- a/asciidoctor-gradle-jvm-epub/src/main/groovy/org/asciidoctor/gradle/jvm/epub/AsciidoctorJEpubPlugin.groovy
+++ b/asciidoctor-gradle-jvm-epub/src/main/groovy/org/asciidoctor/gradle/jvm/epub/AsciidoctorJEpubPlugin.groovy
@@ -18,6 +18,7 @@ package org.asciidoctor.gradle.jvm.epub
 import groovy.transform.CompileStatic
 import org.asciidoctor.gradle.jvm.AsciidoctorJBasePlugin
 import org.asciidoctor.gradle.jvm.AsciidoctorJExtension
+import org.asciidoctor.gradle.kindlegen.KindleGenBasePlugin
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -39,8 +40,8 @@ class AsciidoctorJEpubPlugin implements Plugin<Project> {
 
     void apply(Project project) {
         project.with {
-            apply plugin: 'org.asciidoctor.jvm.base'
-            apply plugin: 'org.asciidoctor.kindlegen.base'
+            apply plugin: AsciidoctorJBasePlugin
+            apply plugin: KindleGenBasePlugin
 
             extensions.getByType(AsciidoctorJExtension).modules.epub.use()
 

--- a/asciidoctor-gradle-jvm-gems/src/main/groovy/org/asciidoctor/gradle/jvm/gems/AsciidoctorGemSupportPlugin.groovy
+++ b/asciidoctor-gradle-jvm-gems/src/main/groovy/org/asciidoctor/gradle/jvm/gems/AsciidoctorGemSupportPlugin.groovy
@@ -18,6 +18,7 @@ package org.asciidoctor.gradle.jvm.gems
 import com.github.jrubygradle.JRubyPluginExtension
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
+import org.asciidoctor.gradle.jvm.AsciidoctorJBasePlugin
 import org.asciidoctor.gradle.jvm.AsciidoctorJExtension
 import org.gradle.api.Action
 import org.gradle.api.Plugin
@@ -47,7 +48,7 @@ class AsciidoctorGemSupportPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        project.apply plugin: 'org.asciidoctor.jvm.base'
+        project.apply plugin: AsciidoctorJBasePlugin
         Configuration gemConfig = project.configurations.maybeCreate(GEM_CONFIGURATION)
 
         Action gemPrepDefaults = new Action<AsciidoctorGemPrepare>() {

--- a/asciidoctor-gradle-jvm-slides/src/main/groovy/org/asciidoctor/gradle/jvm/slides/AsciidoctorRevealJSBasePlugin.groovy
+++ b/asciidoctor-gradle-jvm-slides/src/main/groovy/org/asciidoctor/gradle/jvm/slides/AsciidoctorRevealJSBasePlugin.groovy
@@ -17,8 +17,10 @@ package org.asciidoctor.gradle.jvm.slides
 
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
+import org.asciidoctor.gradle.jvm.AsciidoctorJBasePlugin
 import org.asciidoctor.gradle.jvm.AsciidoctorJExtension
 import org.asciidoctor.gradle.jvm.gems.AsciidoctorGemPrepare
+import org.asciidoctor.gradle.jvm.gems.AsciidoctorGemSupportPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.ysb33r.grolifant.api.TaskProvider
@@ -37,8 +39,8 @@ class AsciidoctorRevealJSBasePlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        project.apply plugin: 'org.asciidoctor.jvm.gems'
-        project.apply plugin: 'org.asciidoctor.jvm.base'
+        project.apply plugin: AsciidoctorGemSupportPlugin
+        project.apply plugin: AsciidoctorJBasePlugin
 
         project.extensions.create(RevealJSPluginExtension.NAME, RevealJSPluginExtension, project)
         project.extensions.create(RevealJSExtension.NAME, RevealJSExtension, project)

--- a/asciidoctor-gradle-jvm-slides/src/main/groovy/org/asciidoctor/gradle/jvm/slides/AsciidoctorRevealJSPlugin.groovy
+++ b/asciidoctor-gradle-jvm-slides/src/main/groovy/org/asciidoctor/gradle/jvm/slides/AsciidoctorRevealJSPlugin.groovy
@@ -33,7 +33,7 @@ class AsciidoctorRevealJSPlugin implements Plugin<Project> {
     @Override
     @SuppressWarnings('LineLength')
     void apply(Project project) {
-        project.apply plugin: 'org.asciidoctor.jvm.revealjs.base'
+        project.apply plugin: AsciidoctorRevealJSBasePlugin
 
         AsciidoctorGemPrepare gemPrepare = (AsciidoctorGemPrepare)(project.tasks.getByName(AsciidoctorGemSupportPlugin.GEMPREP_TASK))
         AsciidoctorJRevealJSTask revealTask = project.tasks.create(REVEALJS_TASK, AsciidoctorJRevealJSTask)

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/compat/AsciidoctorCompatibilityPlugin.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/compat/AsciidoctorCompatibilityPlugin.groovy
@@ -18,6 +18,7 @@ package org.asciidoctor.gradle.compat
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.asciidoctor.gradle.AsciidoctorTask
+import org.asciidoctor.gradle.base.AsciidoctorBasePlugin
 import org.asciidoctor.gradle.jvm.AsciidoctorJBasePlugin
 import org.gradle.api.Action
 import org.gradle.api.GradleException
@@ -71,7 +72,7 @@ class AsciidoctorCompatibilityPlugin implements Plugin<Project> {
             }
         }
 
-        project.apply plugin: 'org.asciidoctor.base'
+        project.apply plugin: AsciidoctorBasePlugin
 
         AsciidoctorExtension extension = project.extensions.create(ASCIIDOCTORJ, AsciidoctorExtension, project)
 

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJBasePlugin.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJBasePlugin.groovy
@@ -16,6 +16,7 @@
 package org.asciidoctor.gradle.jvm
 
 import groovy.transform.CompileStatic
+import org.asciidoctor.gradle.base.AsciidoctorBasePlugin
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -37,7 +38,7 @@ class AsciidoctorJBasePlugin implements Plugin<Project> {
 
     void apply(Project project) {
         project.with {
-            apply plugin: 'org.asciidoctor.base'
+            apply plugin: AsciidoctorBasePlugin
 
             AsciidoctorJExtension asciidoctorj = extensions.create(
                 AsciidoctorJExtension.NAME,

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJPdfPlugin.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJPdfPlugin.groovy
@@ -38,7 +38,7 @@ class AsciidoctorJPdfPlugin implements Plugin<Project> {
 
     void apply(Project project) {
         project.with {
-            apply plugin: 'org.asciidoctor.jvm.base'
+            apply plugin: AsciidoctorJBasePlugin
 
             extensions.create(AsciidoctorPdfThemesExtension.NAME, AsciidoctorPdfThemesExtension, project)
             extensions.getByType(AsciidoctorJExtension).modules.pdf.use()

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJPlugin.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJPlugin.groovy
@@ -30,7 +30,7 @@ import static org.ysb33r.grolifant.api.TaskProvider.registerTask
 class AsciidoctorJPlugin implements Plugin<Project> {
 
     void apply(Project project) {
-        project.apply plugin: 'org.asciidoctor.jvm.base'
+        project.apply plugin: AsciidoctorJBasePlugin
 
         Action asciidoctorDefaults = new Action<AsciidoctorTask>() {
             @Override


### PR DESCRIPTION
- Use fully qualified class name when applying plugin to workaround https://github.com/gradle/gradle/issues/1262

Background:
In the organization I work with, asciidoctor is used in gradle builds via a custom script plugin that is copied to the "gradle" folder of the projects that need asciidoctor. The script plugin is activated by applying the script plugin in the gradle build.
This solution is currently using asciidoctor-gradle-plugin version 1.5.7. When I tried to upgrade the version to the latest plugin version, I noticed that the internal usage of applying plugins doesn't work with script plugins and I wasn't able to upgrade the solution.
