### PR TITLE
Fix version of bibtex-ruby to 4.4.7 for test purposes

### DIFF
--- a/asciidoctor-gradle-jvm-gems/src/gradleTest/external-gems/build.gradle
+++ b/asciidoctor-gradle-jvm-gems/src/gradleTest/external-gems/build.gradle
@@ -9,11 +9,14 @@ apply from: "${System.getProperty('OFFLINE_REPO')}/repositories.gradle"
 
 // tag::use-gems[]
 repositories {
-    maven { url 'http://rubygems-proxy.torquebox.org/releases' } // <2>
+    maven { url 'http://rubygems-proxy.torquebox.org/releases' } // <1>
 }
 
 dependencies {
     asciidoctorGems 'rubygems:asciidoctor-bibtex:0.3.1'
+    asciidoctorGems 'rubygems:bibtex-ruby:4.4.7', {
+        force = true
+    }
 }
 
 asciidoctorj {


### PR DESCRIPTION
Tests are failing due to a bibtex-ruby update on June 12. In order to prevent this from affecting anyone working on 2.x this merge should go straight to master.

This locks the version of transitive dependency bibtex-ruby version to 4.4.7