### PR TITLE
Source trees should report all language source sets (#401)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -482,7 +482,7 @@ resources {
 }
 ----
 
-In case of languages the defeault behvaiour is
+In case of languages the default behvaiour is
 
 [source,groovy]
 .build.gradle

--- a/asciidoctor-gradle-base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
+++ b/asciidoctor-gradle-base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
@@ -263,8 +263,11 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
 
     /** Returns a FileTree containing all of the source documents
      *
-     * @return If{@code sources} was never called then all asciidoc source files below {@code sourceDir} will
-     * be included.
+     * If a filter with {@link #sources} was never set then all asciidoc source files
+     * below {@link #setSourceDir} will be included. If multiple languages are used all
+     * of the language source sets be will included.
+     *
+     * @return Applicable source trees.
      *
      * @since 1.5.1
      */
@@ -272,18 +275,34 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
     @SkipWhenEmpty
     @PathSensitive(RELATIVE)
     FileTree getSourceFileTree() {
-        getSourceFileTreeFrom(sourceDir)
+        if (languages.empty) {
+            getSourceFileTreeFrom(sourceDir)
+        } else {
+            languages.sum { lang ->
+                getLanguageSourceFileTree(lang)
+            } as FileTree
+        }
     }
 
     /** Returns a FileTree containing all of the secondary source documents.
      *
-     * @return Collection of secondary files
+     * If a filter with {@link #secondarySources} was never set then all asciidoc source files
+     * below {@link #setSourceDir} will be included. If multiple languages are used all
+     * of the language secondary source sets be will included.
+     *
+     * @return Collection of secondary source files
      *
      */
     @InputFiles
     @PathSensitive(RELATIVE)
     FileTree getSecondarySourceFileTree() {
-        getSecondarySourceFileTreeFrom(sourceDir)
+        if (languages.empty) {
+            getSecondarySourceFileTreeFrom(sourceDir)
+        } else {
+            languages.sum { lang ->
+                getLanguageSecondarySourceFileTree(lang)
+            } as FileTree
+        }
     }
 
     /** Add to the CopySpec for extra files. The destination of these files will always have a parent directory

--- a/asciidoctor-gradle-jvm-leanpub/src/main/groovy/org/asciidoctor/gradle/jvm/leanpub/DropboxCopyTask.groovy
+++ b/asciidoctor-gradle-jvm-leanpub/src/main/groovy/org/asciidoctor/gradle/jvm/leanpub/DropboxCopyTask.groovy
@@ -76,7 +76,7 @@ class DropboxCopyTask extends DefaultTask {
         this.bookPath != null ? StringUtils.stringize(this.bookPath) : null
     }
 
-    /** Sets the relative path of the eanpub book in Dropbox.
+    /** Sets the relative path of the Leanpub book in Dropbox.
      *
      * @param p Relative path of Leanpub as synchronised to Dropbox.
      */

--- a/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/MultiLanguageFunctionalSpec.groovy
+++ b/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/MultiLanguageFunctionalSpec.groovy
@@ -43,6 +43,10 @@ class MultiLanguageFunctionalSpec extends FunctionalSpecification {
             languages 'en', 'es'
 
             sourceDir 'src/docs/asciidoc'
+
+            sources {
+                include 'sample.asciidoc'
+            }
         }
         """)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 3.0.0-alpha.2
+version = 3.0.0-alpha.3
 group = org.asciidoctor
 sourceCompatibility = 1.8
 targetCompatibility = 1.8


### PR DESCRIPTION
`getSourceFileTree` and `getSecondarySourceFileTree` now reports all of the source sets when
multiple languages are specified. This fix distinguishes between classic behaviour and
multi-language behaviour and will either return a single source set of a combination of source sets.

Credits to @ixchelruiz for helping to diagnose this problem at Hack.Commit.Push 2019.