### PR TITLE
Inject `lang` attribute for multiple language source sets (#411)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,7 +35,7 @@ ifdef::env-github[]
 endif::[]
 
 ifdef::env-github[]
-NOTE: `master` now represents the code for the latest 2.x release of these plugins. Development for for 2.x is against the link:https://github.com/asciidoctor/asciidoctor-gradle-plugin/tree/development-2.0[development-2.0] branch. PRs are preferably taking against that branch. The 1.5.x series of the plugin is now in maintenance only mode. PRs for that should be raised against the https://github.com/asciidoctor/asciidoctor-gradle-plugin/tree/maintenance-1.5[maintenance-1.5] branch.
+NOTE: `master` now represents the code for the latest 2.x release of these plugins. Development for for 2.x is against the link:https://github.com/asciidoctor/asciidoctor-gradle-plugin/tree/development-2.0[development-2.0] branch. PRs are preferably taking against that branch. The 1.5.x series of the plugin is now in maintenance only mode. PRs for that should be raised against the https://github.com/asciidoctor/asciidoctor-gradle-plugin/tree/maintenance-1.5[maintenance-1.5] branch. PRs for the next generation work could preferably be raised against link:https://github.com/asciidoctor/asciidoctor-gradle-plugin/tree/development-3.x[development-3.x]
 endif::[]
 
 ifdef::status[]
@@ -161,11 +161,13 @@ asciidoctor {
 The entities that can be set are:
 
 [horizontal]
-attributes:: {asciidoctorj-epub-name} attributes.
-  Use `attributes` to append and `setAttributes` to replace any current attributes with a new set.
-  Attribute values are lazy-evaluated to strings.
 attributeProvider:: Register an additional provider of attributes.
   Attribute providers are a means of adding attributes that will not affect the up-to-date status of tasks.
+attributes:: {asciidoctorj-name} attributes.
+  Use `attributes` to append and `setAttributes` to replace any current attributes with a new set.
+  Attribute values are lazy-evaluated to strings.
+attributesForLang:: Language-specific attributes.
+  Specify additional attributes which will only be added if a  source set for the specified language is being processed.
 docExtensions:: Groovy DSL extensions.
   Use `docExtensions` to add one or more extensions. Use `setDocExtensions` to replace the current set of extensions with a new set.
   Extensions can be any kind of object that is serialisable, although in most cases they will be strings or files.
@@ -555,7 +557,7 @@ When using the `docinfo` attribute with `html` and `docbook` backends, it is rec
 
 === Source language support
 
-Some scenarios work on a source set of docuemtns in a primary language and then translations of those sources into other languages. The Gradle plugin simplifies this scenario by allowing a structure such as
+Some scenarios work on a source set of documents in a primary language and then translations of those sources into other languages. The Gradle plugin simplifies this scenario by allowing a structure such as
 
 [source]
 ----
@@ -576,7 +578,24 @@ asciidoctor {
 }
 ----
 
-Gradle will then process both the `en` and the `es` source set and output to the output directory using the same languages names. Intermediate working directories and multiple backends are also covered.
+Gradle will then process both the `en` and the `es` source set and output to the output directory using the same languages names. Intermediate working directories and multiple backends are also covered. In this case the `lang` attribute will be injected with the specific language as the value.
+
+It is also possible to specify additional attributes that will only be added when a specific language is processed
+
+[source,groovy]
+----
+asciidoctorj { // <1>
+    attributesForLang 'en', langName : 'English'
+    attributesForLang 'ca', langName : 'Catala'
+}
+
+asciidoctorjs { // <2>
+    attributesForLang 'en', langName : 'English'
+    attributesForLang 'ca', langName : 'Catala'
+}
+----
+<1> Configuration when using {asciidoctorj-name}
+<2> Configuration when using {asciidoctorjs-name}
 
 == The New AsciidoctorJ Plugin
 

--- a/README.adoc
+++ b/README.adoc
@@ -65,7 +65,7 @@ This is still an alpha development, so expect some issues. These are the main on
 
 == Installation
 
-To start you need to use one of the plugins from the following Gradle snipper
+To start you need to use one of the plugins from the following Gradle snippet
 
 [source,groovy]
 [subs=attributes+]
@@ -83,7 +83,7 @@ For the {kotlindsl} the format is slightly different:
 .build.gradle.kts
 ----
 plugins {
-    id("org.asciidoctor.convert") version "{version-published}"
+    id("org.asciidoctor.jvm.convert") version "{version-published}"
 }
 ----
 

--- a/asciidoctor-gradle-base/src/test/groovy/org/asciidoctor/gradle/base/AbstractImplementationEngineExtensionSpec.groovy
+++ b/asciidoctor-gradle-base/src/test/groovy/org/asciidoctor/gradle/base/AbstractImplementationEngineExtensionSpec.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle.base
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class AbstractImplementationEngineExtensionSpec extends Specification {
+    public static final String EXTNAME = 'sample'
+    public static final String EN = 'en'
+    public static final String ES = 'es'
+
+    Project project = ProjectBuilder.builder().build()
+    TestExtension projectExtension
+    TestExtension taskExtension
+    Task proxyTask
+
+    void setup() {
+        projectExtension = project.extensions.create(EXTNAME, TestExtension, project)
+        proxyTask = project.tasks.create('proxyTask')
+        taskExtension = proxyTask.extensions.create(EXTNAME, TestExtension, proxyTask, EXTNAME)
+    }
+
+    void 'Can set language-specific attributes at project level'() {
+        when:
+        projectExtension.attributesForLang EN, foo: 'bar'
+
+        then:
+        projectExtension.getAttributesForLang(ES).isEmpty()
+        projectExtension.getAttributesForLang(EN).foo == 'bar'
+    }
+
+    void 'Can augment language-specific attributes at task level'() {
+        when:
+        projectExtension.attributesForLang EN, foo: 'bar'
+        taskExtension.attributesForLang EN, foo2: 'bar2'
+
+        then:
+        taskExtension.getAttributesForLang(ES).isEmpty()
+        taskExtension.getAttributesForLang(EN).foo == 'bar'
+        taskExtension.getAttributesForLang(EN).foo2 == 'bar2'
+        !projectExtension.getAttributesForLang(EN).foo2
+    }
+
+    void 'Can reset language-specific attributes at task level'() {
+        when:
+        projectExtension.attributesForLang EN, foo: 'bar'
+        taskExtension.resetAttributesForLang EN, foo2: 'bar2'
+
+        then:
+        taskExtension.getAttributesForLang(ES).isEmpty()
+        !taskExtension.getAttributesForLang(EN).foo
+        taskExtension.getAttributesForLang(EN).foo2 == 'bar2'
+        !projectExtension.getAttributesForLang(EN).foo2
+    }
+
+    static class TestExtension extends AbstractImplementationEngineExtension {
+        TestExtension(Project project) {
+            super(project, 'org.asciidoctor.gradle.base.test')
+        }
+
+        TestExtension(Task task, String name) {
+            super(task, name)
+        }
+    }
+}

--- a/asciidoctor-gradle-base/src/test/resources/META-INF/asciidoctor.gradle/org.asciidoctor.gradle.base.test.properties
+++ b/asciidoctor-gradle-base/src/test/resources/META-INF/asciidoctor.gradle/org.asciidoctor.gradle.base.test.properties
@@ -1,0 +1,16 @@
+#
+# Copyright 2013-2019 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+


### PR DESCRIPTION
When multiple languages have been specified `lang@` will be injected with a value
as specified for the specific language.

It is also now possible to specify additional attributes that will only be injected when a specific language is being converted.