### PR TITLE
Report dependencies for any Asciidoctor task (#393)

### DIFF
--- a/asciidoctor-gradle-base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
+++ b/asciidoctor-gradle-base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileTree
 import org.gradle.api.provider.Provider
@@ -561,6 +562,15 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
      */
     @Internal
     abstract List<AsciidoctorAttributeProvider> getAttributeProviders()
+
+    /** Configurations for which dependencies should be reported.
+     *
+     * @return Set of configurations. Can be empty, but never {@code null}.
+     *
+     * @since 2.3.0 (Moved from org.asciidoctor.gradle.jvm)
+     */
+    @Internal
+    abstract Set<Configuration> getReportableConfigurations()
 
     protected AbstractAsciidoctorBaseTask() {
         super()

--- a/asciidoctor-gradle-base/src/main/groovy/org/asciidoctor/gradle/base/internal/ConfigurationUtils.groovy
+++ b/asciidoctor-gradle-base/src/main/groovy/org/asciidoctor/gradle/base/internal/ConfigurationUtils.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle.base.internal
+
+import groovy.transform.CompileStatic
+import org.asciidoctor.gradle.base.Transform
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.provider.Provider
+import org.ysb33r.grolifant.api.StringUtils
+
+/** Utilities for dealing with Configurations
+ *
+ * @since 3.0.0
+ */
+@CompileStatic
+class ConfigurationUtils {
+
+    /** Extracts a {@link Configuration} if possible.
+     *
+     * @param project Associated project
+     * @param sourceConfig Item that could be a source of a configuration
+     * @return {@link Configuration} instance
+     *
+     * @throw {@code UnknownConfigurationException}
+     */
+    static Configuration asConfiguration(Project project, Object sourceConfig) {
+        switch (sourceConfig) {
+            case Configuration:
+                return (Configuration) sourceConfig
+            case Provider:
+                return asConfiguration(project, ((Provider) sourceConfig).get())
+            default:
+                project.configurations.getByName(StringUtils.stringize(sourceConfig))
+        }
+    }
+
+    /** Extracts a list of {@link Configuration} instances.
+     *
+     * @param project Associated project.
+     * @param sourceConfigs Collection of items that could be sources of configurations.
+     * @return List of {@link Configuration} instances.
+     *
+     * @throw {@code UnknownConfigurationException}
+     */
+    static List<Configuration> asConfigurations(Project project, Collection<Object> sourceConfigs) {
+        Transform.toList(sourceConfigs) {
+            asConfiguration(project, it)
+        }
+    }
+}

--- a/asciidoctor-gradle-base/src/test/groovy/org/asciidoctor/gradle/base/AsciidoctorBasePluginSpec.groovy
+++ b/asciidoctor-gradle-base/src/test/groovy/org/asciidoctor/gradle/base/AsciidoctorBasePluginSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle.base
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class AsciidoctorBasePluginSpec extends Specification {
+    Project project = ProjectBuilder.builder().build()
+
+    void 'Applying the plugin will add a report task rule'() {
+        given:
+        project.allprojects {
+            apply plugin: 'org.asciidoctor.base'
+            tasks.create 'foo', TestTask
+        }
+
+        when:
+        project.tasks.getByName('fooDependencies')
+
+        then:
+        noExceptionThrown()
+    }
+
+    static class TestTask extends AbstractAsciidoctorBaseTask {
+        Map<String, Object> attributes
+        List<AsciidoctorAttributeProvider> attributeProviders
+        Set<Configuration> reportableConfigurations = []
+
+        @Override
+        void attributes(Map<String, Object> m) {
+        }
+
+        @Override
+        protected String getEngineName() {
+            null
+        }
+    }
+}

--- a/asciidoctor-gradle-js/src/main/groovy/org/asciidoctor/gradle/js/nodejs/AbstractAsciidoctorNodeJSTask.groovy
+++ b/asciidoctor-gradle-js/src/main/groovy/org/asciidoctor/gradle/js/nodejs/AbstractAsciidoctorNodeJSTask.groovy
@@ -21,6 +21,7 @@ import org.asciidoctor.gradle.base.AsciidoctorAttributeProvider
 import org.asciidoctor.gradle.base.internal.Workspace
 import org.asciidoctor.gradle.js.base.AbstractAsciidoctorTask
 import org.asciidoctor.gradle.js.nodejs.internal.AsciidoctorJSRunner
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
@@ -87,6 +88,15 @@ class AbstractAsciidoctorNodeJSTask extends AbstractAsciidoctorTask {
     @Internal
     List<AsciidoctorAttributeProvider> getAttributeProviders() {
         asciidoctorjs.attributeProviders
+    }
+
+    /** Configurations for which dependencies should be reported.
+     *
+     * @return Set of configurations. Can be empty, but never {@code null}.
+     */
+    @Override
+    Set<Configuration> getReportableConfigurations() {
+        [asciidoctorjs.configuration].toSet()
     }
 
     @TaskAction

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJBasePlugin.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJBasePlugin.groovy
@@ -17,18 +17,13 @@ package org.asciidoctor.gradle.jvm
 
 import groovy.transform.CompileStatic
 import org.asciidoctor.gradle.base.AsciidoctorBasePlugin
-import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.tasks.diagnostics.DependencyReportTask
-
-import static org.ysb33r.grolifant.api.TaskProvider.registerTask
 
 /**
-* @author Schalk W. Cronjé
-*
-* @since 2.0.0
+ * @author Schalk W. Cronjé
+ *
+ * @since 2.0.0
  */
 @CompileStatic
 class AsciidoctorJBasePlugin implements Plugin<Project> {
@@ -40,18 +35,11 @@ class AsciidoctorJBasePlugin implements Plugin<Project> {
         project.with {
             apply plugin: AsciidoctorBasePlugin
 
-            AsciidoctorJExtension asciidoctorj = extensions.create(
+            extensions.create(
                 AsciidoctorJExtension.NAME,
                 AsciidoctorJExtension,
                 project
             )
-
-            registerTask(project, DEPS_REPORT, DependencyReportTask, new Action<Task>() {
-                @Override
-                void execute(Task task) {
-                    ((DependencyReportTask) task).configurations = [asciidoctorj.configuration].toSet()
-                }
-            })
         }
     }
 }

--- a/asciidoctor-gradle-jvm/src/test/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJBasePluginSpec.groovy
+++ b/asciidoctor-gradle-jvm/src/test/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJBasePluginSpec.groovy
@@ -18,7 +18,6 @@ package org.asciidoctor.gradle.jvm
 import org.asciidoctor.gradle.base.ModuleVersionLoader
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.tasks.diagnostics.DependencyReportTask
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Shared
 import spock.lang.Specification
@@ -26,7 +25,7 @@ import spock.lang.Specification
 class AsciidoctorJBasePluginSpec extends Specification {
 
     @Shared
-    Map<String,String> versionMap = ModuleVersionLoader.load('asciidoctorj-extension')
+    Map<String, String> versionMap = ModuleVersionLoader.load('asciidoctorj-extension')
 
     Project project = ProjectBuilder.builder().build()
 
@@ -45,19 +44,6 @@ class AsciidoctorJBasePluginSpec extends Specification {
             ext.modules.pdf.version == null
             ext.modules.epub.version == null
         }
-    }
-
-    void 'Apply the plugin will add a report task for AsciidoctorJ'() {
-        when:
-        project.allprojects {
-            apply plugin: 'org.asciidoctor.jvm.base'
-        }
-
-        project.evaluate()
-        DependencyReportTask task = project.tasks.getByName(AsciidoctorJBasePlugin.DEPS_REPORT)
-
-        then:
-        !task.configurations.first().dependencies.empty
     }
 
     void 'Adding extension will set GroovyDSL'() {


### PR DESCRIPTION
Apply rule such that if task AsciidoctorAbc exists then AsciidoctorAbcDependencies
will be a report task of all of the appropriate dependencies.

For AsciidoctorJ the runtime dependencies and additional GEMs are reported.

For AsciidoctorJS the Node.JS modules are reported.