### PR TITLE
Exclude secondary source elements by matching rather than subtraction

### DIFF
--- a/asciidoctor-gradle-jvm-epub/src/main/groovy/org/asciidoctor/gradle/jvm/epub/AsciidoctorEpubTask.groovy
+++ b/asciidoctor-gradle-jvm-epub/src/main/groovy/org/asciidoctor/gradle/jvm/epub/AsciidoctorEpubTask.groovy
@@ -60,7 +60,7 @@ class AsciidoctorEpubTask extends AbstractAsciidoctorTask {
         kindleGenExtension = project.extensions.getByType(KindleGenExtension)
         sourceDir = 'src/docs/asciidocEpub'
 
-        // TODO: We are setting this curretnly to fix a problem in asciidoctor-epub GEM.
+        // TODO: We are setting this currently to fix a problem in asciidoctor-epub GEM.
         useIntermediateWorkDir()
     }
 


### PR DESCRIPTION
Exclude secondary source elements by matching rather than subtraction (#410)

This is a very subtle issue. When two Filtree instances are subtracted from each other
in order to eliminate a set of files, the base directory of the tree is lost. If this is
in a CopySpec the relative paths will thus also be lost. The solution is to use a matcher
of type PatternFilterable and then to exclude by FileTreeElement.

When using