### PR TITLE
Make tasks cacheable

### DIFF
--- a/asciidoctor-gradle-jvm-epub/src/main/groovy/org/asciidoctor/gradle/jvm/epub/AsciidoctorEpubTask.groovy
+++ b/asciidoctor-gradle-jvm-epub/src/main/groovy/org/asciidoctor/gradle/jvm/epub/AsciidoctorEpubTask.groovy
@@ -22,6 +22,7 @@ import org.asciidoctor.gradle.jvm.AbstractAsciidoctorTask
 import org.asciidoctor.gradle.jvm.AsciidoctorExecutionException
 import org.asciidoctor.gradle.jvm.ProcessMode
 import org.asciidoctor.gradle.kindlegen.KindleGenExtension
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.process.JavaForkOptions
@@ -37,6 +38,7 @@ import javax.inject.Inject
  * @author Schalk W. Cronjé
  */
 @CompileStatic
+@CacheableTask
 class AsciidoctorEpubTask extends AbstractAsciidoctorTask {
 
     static final String KF8 = 'kf8'

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorPdfTask.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorPdfTask.groovy
@@ -32,6 +32,7 @@ import javax.inject.Inject
  * @author Schalk W. Cronjé
  */
 @CompileStatic
+@CacheableTask
 class AsciidoctorPdfTask extends AbstractAsciidoctorTask {
 
     private Object fontsDir

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTask.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTask.groovy
@@ -17,6 +17,7 @@ package org.asciidoctor.gradle.jvm
 
 import groovy.transform.CompileStatic
 import org.gradle.api.Action
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.workers.WorkerExecutor
 import org.ysb33r.grolifant.api.FileUtils
@@ -50,6 +51,7 @@ import static groovy.lang.Closure.DELEGATE_FIRST
  */
 @SuppressWarnings(['MethodCount', 'Instanceof'])
 @CompileStatic
+@CacheableTask
 class AsciidoctorTask extends AbstractAsciidoctorTask {
 
     /** Configures output options for this task.


### PR DESCRIPTION
This is a followup to https://github.com/asciidoctor/asciidoctor-gradle-plugin/pull/215.

Since Gradle 5.0 only adding `@CacheableTask` is needed.

This should not break compatibility with earlier Gradle versions:

- Gradle versions prior to the introduction of the `@CacheableTask` annotation (before 3.0) will just not see the annotation,
- Gradle versions prior 5.0 will emit a deprecation warning about an `@OutputDirectories` property being a `Set<>` and disable caching, but otherwise succeed,
- Gradle versions 5.0 and later will cache the output as intended.