### PR TITLE
Remove outdated Spring REST Docs incompatibility notes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,8 +47,6 @@ The {doctitle} is the official means of using {asciidoctor-url}[Asciidoctor] to 
 
 Documentation:: We are migrating our documentation to the new Asciidoctor Antora-based site when it is ready. In the meantime you can read a snapshot of the new documentation at {asciidoctor-development-docs}{github-branch}
 
-Incompatibilities:: The 2.x range of these plugins are NOT compatible with https://github.com/spring-projects/spring-restdocs[Spring REST Docs]. If you have to use the latter then stick to the older v1.5.11 or v1.5.12 versions and do not manually set the version of {asciidoctorj-name} in your build script.
-
 ifdef::env-github[]
 Structure:: `master` now represents the code for the latest 2.x release of these plugins. Development for for 2.x is against the link:https://github.com/asciidoctor/asciidoctor-gradle-plugin/tree/development-2.0[development-2.0] branch. PRs are preferably taking against that branch. The 1.5.x series of the plugin is now in maintenance only mode. PRs for that should be raised against the https://github.com/asciidoctor/asciidoctor-gradle-plugin/tree/maintenance-1.5[maintenance-1.5] branch.
 endif::[]

--- a/docs/src/docs/asciidoc/parts/compatibility.adoc
+++ b/docs/src/docs/asciidoc/parts/compatibility.adoc
@@ -1,5 +1,3 @@
 == Compatibility
 
 This collection of plugins requires at least Gradle 4.0, JDK 8.0 and {asciidoctorj-name} 1.6.0 to run. If you need prior Gradle,  JDK or {asciidoctorj-name} support please use a plugin from the 1.5.x or 1.6.x release series.
-
-The 2.x range of these plugins are NOT compatible with https://github.com/spring-projects/spring-restdocs[Spring REST Docs]. If you have to use the latter then stick to the older v1.5.11 or v1.5.12 versions and do not manually set the version of {asciidoctorj-name} in your build script.


### PR DESCRIPTION
This PR removes outdated Spring REST Docs incompatibility notes as it does seem to be compatibile now.

See https://github.com/spring-projects/spring-restdocs/issues/581 and https://github.com/spring-projects/spring-restdocs/issues/630