### PR TITLE
Fix include directive for asciidoctorj-custom-extensions.adoc

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -27,7 +27,7 @@ include::parts/asciidoctorj-gems-plugin.adoc[]
 
 include::parts/kindlegen-plugin.adoc[]
 
-include::parts/asciidoctorj-custom-extensions.adoc
+include::parts/asciidoctorj-custom-extensions.adoc[]
 
 include::parts/upgrading.adoc[]
 


### PR DESCRIPTION
This PR fixes `include` directive for `asciidoctorj-custom-extensions.adoc`.