### PR TITLE
Avoid deprecation warning for `baseDirConfigured` with Gradle 6.0

### DIFF
--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -878,6 +878,7 @@ class AbstractAsciidoctorTask extends DefaultTask {
      *
      * @return {@code true} is a strategy has been configured
      */
+    @Internal
     protected boolean isBaseDirConfigured() {
         this.baseDir != null
     }


### PR DESCRIPTION
Gradle 6.0+ will print this message when warnings are enabled.

```
> Task :asciidoctor
Property 'baseDirConfigured' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
```

Using `@Internal` annotation dismiss the public property from up-to-date checks, and as such prevent warnings.