### PR TITLE
Fix deprecation issue when using Gradle 6

### DIFF
--- a/asciidoctor-gradle-jvm-epub/src/intTest/groovy/org/asciidoctor/gradle/jvm/epub/AsciidoctorEpubTaskFunctionalSpec.groovy
+++ b/asciidoctor-gradle-jvm-epub/src/intTest/groovy/org/asciidoctor/gradle/jvm/epub/AsciidoctorEpubTaskFunctionalSpec.groovy
@@ -135,6 +135,23 @@ class AsciidoctorEpubTaskFunctionalSpec extends FunctionalSpecification {
         result.output.contains('No eBook format specified for task')
     }
 
+    @Unroll
+    void 'there are no deprecated usages with Gradle v#version'() {
+        given:
+        getSingleFormatBuildFile('EPUB3')
+
+        when:
+        BuildResult result = getGradleRunner(['asciidoctorEpub', '--warning-mode', 'all'])
+                .withGradleVersion(version)
+                .build()
+
+        then:
+        assertNoDeprecatedUsages(result)
+
+        where:
+        version << ['5.6.4', '6.0.1']
+    }
+
     File getSingleFormatBuildFile(final String format) {
         getBuildFile( """
 

--- a/asciidoctor-gradle-jvm-gems/src/intTest/groovy/org/asciidoctor/gradle/jvm/gems/AsciidoctorGemPrepareTaskCachingFunctionalSpec.groovy
+++ b/asciidoctor-gradle-jvm-gems/src/intTest/groovy/org/asciidoctor/gradle/jvm/gems/AsciidoctorGemPrepareTaskCachingFunctionalSpec.groovy
@@ -170,7 +170,14 @@ class AsciidoctorGemPrepareTaskCachingFunctionalSpec extends FunctionalSpecifica
             ${offlineRepositories}
 
             repositories {
-                maven { url 'http://rubygems-proxy.torquebox.org/releases' }
+                maven { 
+                    url 'http://rubygems-proxy.torquebox.org/releases'
+                    try {
+                        allowInsecureProtocol = true
+                    } catch (Exception ignore) {
+                        // available for Gradle 6.0+
+                    }
+                }
             }
 
            ${extraContent}

--- a/asciidoctor-gradle-jvm-gems/src/intTest/groovy/org/asciidoctor/gradle/jvm/gems/AsciidoctorGemPrepareTaskCachingFunctionalSpec.groovy
+++ b/asciidoctor-gradle-jvm-gems/src/intTest/groovy/org/asciidoctor/gradle/jvm/gems/AsciidoctorGemPrepareTaskCachingFunctionalSpec.groovy
@@ -170,7 +170,7 @@ class AsciidoctorGemPrepareTaskCachingFunctionalSpec extends FunctionalSpecifica
             ${offlineRepositories}
 
             repositories {
-                maven { 
+                maven {
                     url 'http://rubygems-proxy.torquebox.org/releases'
                     try {
                         allowInsecureProtocol = true

--- a/asciidoctor-gradle-jvm-gems/src/intTest/groovy/org/asciidoctor/gradle/jvm/gems/internal/FunctionalSpecification.groovy
+++ b/asciidoctor-gradle-jvm-gems/src/intTest/groovy/org/asciidoctor/gradle/jvm/gems/internal/FunctionalSpecification.groovy
@@ -16,6 +16,7 @@
 package org.asciidoctor.gradle.jvm.gems.internal
 
 import org.apache.commons.io.FileUtils
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -38,6 +39,9 @@ class FunctionalSpecification extends Specification {
 
     @Rule
     TemporaryFolder alternateProjectDir
+
+    @SuppressWarnings(['PrivateFieldCouldBeFinal'])
+    private List<String> allowedDeprecations = []
 
     GradleRunner getGradleRunner(List<String> taskNames) {
         GradleRunner.create()
@@ -66,5 +70,22 @@ class FunctionalSpecification extends Specification {
         } else {
             "apply from: '${repo.absolutePath}'"
         }
+    }
+
+    void assertNoDeprecatedUsages(BuildResult result) {
+        List<String> outputLines = result.output.readLines()
+
+        outputLines.each { String line ->
+            assert !isUnallowedDeprecation(line) : "Output contains an unallowed deprecation: ${line}"
+        }
+    }
+
+    boolean isUnallowedDeprecation(String line) {
+        line.contains('has been deprecated') &&
+                !allowedDeprecations.any { String allowedDeprecation -> line.startsWith(allowedDeprecation) }
+    }
+
+    void allowDeprecation(String allowedDeprecation) {
+        allowedDeprecations.add(allowedDeprecation)
     }
 }

--- a/asciidoctor-gradle-jvm-slides/src/intTest/groovy/org/asciidoctor/gradle/jvm/slides/AsciidoctorRevealJSTaskFunctionalSpec.groovy
+++ b/asciidoctor-gradle-jvm-slides/src/intTest/groovy/org/asciidoctor/gradle/jvm/slides/AsciidoctorRevealJSTaskFunctionalSpec.groovy
@@ -18,6 +18,7 @@ package org.asciidoctor.gradle.jvm.slides
 import org.asciidoctor.gradle.jvm.slides.internal.FunctionalSpecification
 import org.asciidoctor.gradle.testfixtures.jvm.JRubyTestVersions
 import org.gradle.testkit.runner.BuildResult
+import spock.lang.Unroll
 
 class AsciidoctorRevealJSTaskFunctionalSpec extends FunctionalSpecification {
 
@@ -105,6 +106,29 @@ class AsciidoctorRevealJSTaskFunctionalSpec extends FunctionalSpecification {
             revealjsHtml.contains(pluginConfig)
             new File(testProjectDir.root, "${DEFAULT_REVEALJS_PATH}/plugin/rajgoel/chart/Chart.js").exists()
         }
+    }
+
+    @Unroll
+    void 'there are no deprecated usages with Gradle v#version'() {
+        given:
+        getBuildFile('')
+
+        when:
+        BuildResult result = getGradleRunner(['asciidoctorRevealJs', '--warning-mode', 'all'])
+                .withGradleVersion(version)
+                .build()
+
+        and:
+        // This property comes from a task in the jruby plugin
+        allowDeprecation('Property \'dependencies\' is not annotated with an input or output annotation.')
+        // This is due to the gem repository used in the test (does not appear to be an https alternative)
+        allowDeprecation('Using insecure protocols with repositories has been deprecated.')
+
+        then:
+        assertNoDeprecatedUsages(result)
+
+        where:
+        version << ['5.6.4', '6.0.1']
     }
 
     BuildResult build() {

--- a/asciidoctor-gradle-jvm-slides/src/intTest/groovy/org/asciidoctor/gradle/jvm/slides/internal/FunctionalSpecification.groovy
+++ b/asciidoctor-gradle-jvm-slides/src/intTest/groovy/org/asciidoctor/gradle/jvm/slides/internal/FunctionalSpecification.groovy
@@ -16,6 +16,7 @@
 package org.asciidoctor.gradle.jvm.slides.internal
 
 import org.apache.commons.io.FileUtils
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -38,6 +39,9 @@ class FunctionalSpecification extends Specification {
 
     @Rule
     TemporaryFolder alternateProjectDir
+
+    @SuppressWarnings(['PrivateFieldCouldBeFinal'])
+    private List<String> allowedDeprecations = []
 
     GradleRunner getGradleRunner(List<String> taskNames) {
         GradleRunner.create()
@@ -66,5 +70,22 @@ class FunctionalSpecification extends Specification {
         } else {
             "apply from: '${repo.absolutePath}'"
         }
+    }
+
+    void assertNoDeprecatedUsages(BuildResult result) {
+        List<String> outputLines = result.output.readLines()
+
+        outputLines.each { String line ->
+            assert !isUnallowedDeprecation(line) : "Output contains an unallowed deprecation: ${line}"
+        }
+    }
+
+    boolean isUnallowedDeprecation(String line) {
+        line.contains('has been deprecated') &&
+                !allowedDeprecations.any { String allowedDeprecation -> line.startsWith(allowedDeprecation) }
+    }
+
+    void allowDeprecation(String allowedDeprecation) {
+        allowedDeprecations.add(allowedDeprecation)
     }
 }

--- a/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskFunctionalSpec.groovy
+++ b/asciidoctor-gradle-jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskFunctionalSpec.groovy
@@ -16,6 +16,7 @@
 package org.asciidoctor.gradle.jvm
 
 import org.asciidoctor.gradle.internal.FunctionalSpecification
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import spock.lang.Issue
 import spock.lang.Timeout
@@ -213,6 +214,31 @@ class AsciidoctorTaskFunctionalSpec extends FunctionalSpecification {
         then:
         new File(testProjectDir.root, 'build/docs/asciidoc/sample.html').text
                 .contains('<meta name="asciidoctor-docinfo-test"/>')
+    }
+
+    @Unroll
+    void 'there are no deprecated usages with Gradle v#version'() {
+        given:
+        getBuildFile("""
+            asciidoctor {
+                sourceDir 'src/docs/asciidoc'
+
+                outputOptions {
+                    backends 'html5', 'docbook'
+                }
+            }
+        """)
+
+        when:
+        BuildResult result = getGradleRunner(DEFAULT_ARGS + ['--warning-mode', 'all'])
+                .withGradleVersion(version)
+                .build()
+
+        then:
+        assertNoDeprecatedUsages(result)
+
+        where:
+        version << ['5.6.4', '6.0.1']
     }
 
     File getBuildFile(String extraContent) {

--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorPdfTask.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorPdfTask.groovy
@@ -105,6 +105,7 @@ class AsciidoctorPdfTask extends AbstractAsciidoctorTask {
      *
      * @return Theme name or {@code null} if no theme was set.
      */
+    @Internal
     @SuppressWarnings('LineLength')
     String getThemeName() {
         this.theme != null ? project.extensions.getByType(AsciidoctorPdfThemesExtension).getByName(this.theme).styleName : null

--- a/testfixtures/jvm/src/main/groovy/org/asciidoctor/gradle/testfixtures/jvm/CachingTest.groovy
+++ b/testfixtures/jvm/src/main/groovy/org/asciidoctor/gradle/testfixtures/jvm/CachingTest.groovy
@@ -37,7 +37,7 @@ trait CachingTest {
             rootProject.name = 'test'
 
             buildCache {
-                local(DirectoryBuildCache) {
+                local() {
                     directory = new File(rootDir, 'build-cache')
                 }
             }


### PR DESCRIPTION
This fixes #474 and adds some tests to check for deprecated usages for each of the tasks.

Note that #474 suggests using `@Input` here but the theme name is only used locate the theme directory which is already an input to the task.  The theme name itself is not important to the incrementality or cacheability of the task, hence `@Internal` is more appropriate.

Note also that the `AsciidoctorGemPrepare` task extends from the `JRubyPrepare` task from the jruby plugin which has an un-annotated `dependencies` property which causes a deprecation warning.  This will need to be fixed in the upstream plugin.

cc @facewindu