### PR TITLE
Add missing gradle- prefix to automatically added attributes

### DIFF
--- a/docs/src/docs/asciidoc/parts/asciidoctorj-base-plugin.adoc
+++ b/docs/src/docs/asciidoc/parts/asciidoctorj-base-plugin.adoc
@@ -129,9 +129,9 @@ tasks {
 
 The following attributes are automatically set by the `asciidoctorj` extension:
 
- * project-name : matches `$project.name`
- * project-version: matches `$project.version` (if defined). Empty String value if undefined
- * project-group: matches `$project.group` (if defined). Empty String value if undefined
+ * gradle-project-name : matches `$project.name`
+ * gradle-project-version: matches `$project.version` (if defined). Empty String value if undefined
+ * gradle-project-group: matches `$project.group` (if defined). Empty String value if undefined
 
 These attributes may be overridden by explicit user input.
 


### PR DESCRIPTION
Documents the actual behavior of AsciidoctorJExtension which uses
the `gradle-` prefix.