### PR TITLE
Use property objects for sourceDir and outputDir

### DIFF
--- a/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
+++ b/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
@@ -54,6 +54,7 @@ import java.util.concurrent.Callable
 import static org.asciidoctor.gradle.base.AsciidoctorUtils.UNDERSCORE_LED_FILES
 import static org.asciidoctor.gradle.base.AsciidoctorUtils.executeDelegatingClosure
 import static org.asciidoctor.gradle.base.AsciidoctorUtils.getSourceFileTree
+import static org.asciidoctor.gradle.base.AsciidoctorUtils.mapToDirectoryProvider
 import static org.gradle.api.tasks.PathSensitivity.RELATIVE
 import static org.ysb33r.grolifant.api.FileUtils.filesFromCopySpec
 
@@ -94,7 +95,7 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
      * @param f Any object convertible with {@code project.file}.
      */
     void setSourceDir(Object f) {
-        this.srcDir.set(project.file(f))
+        this.srcDir.set(mapToDirectoryProvider(project, f))
     }
 
     /** Sets the new Asciidoctor parent source directory in a declarative style.
@@ -104,7 +105,7 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
      * @since 3.0
      */
     void sourceDir(Object f) {
-        this.srcDir.set(project.file(f))
+        this.srcDir.set(mapToDirectoryProvider(project, f))
     }
 
     /** Returns the parent directory for Asciidoctor source.

--- a/js/src/main/groovy/org/asciidoctor/gradle/js/nodejs/AsciidoctorTask.groovy
+++ b/js/src/main/groovy/org/asciidoctor/gradle/js/nodejs/AsciidoctorTask.groovy
@@ -25,6 +25,7 @@ import org.ysb33r.grolifant.api.FileUtils
 import javax.inject.Inject
 
 import static groovy.lang.Closure.DELEGATE_FIRST
+import static org.asciidoctor.gradle.base.AsciidoctorUtils.setConvention
 
 /** Build using {@code asciidoctor.js}.
  *
@@ -45,8 +46,8 @@ class AsciidoctorTask extends AbstractAsciidoctorNodeJSTask {
             folderName = "asciidoc${name.capitalize()}"
         }
         final String safeFolderName = FileUtils.toSafeFileName(folderName)
-        sourceDir = "src/docs/${folderName}"
-        outputDir = { project.file("${project.buildDir}/docs/${safeFolderName}") }
+        setConvention(project, sourceDirProperty, project.layout.projectDirectory.dir("src/docs/${folderName}"))
+        setConvention(outputDirProperty, project.layout.buildDirectory.dir("docs/${safeFolderName}"))
     }
 
     /** Configures output options for this task.

--- a/jvm-epub/src/main/groovy/org/asciidoctor/gradle/jvm/epub/AsciidoctorEpubTask.groovy
+++ b/jvm-epub/src/main/groovy/org/asciidoctor/gradle/jvm/epub/AsciidoctorEpubTask.groovy
@@ -60,7 +60,6 @@ class AsciidoctorEpubTask extends AbstractAsciidoctorTask {
         copyNoResources()
         inProcess = JAVA_EXEC
         kindleGenExtension = project.extensions.getByType(KindleGenExtension)
-        sourceDir = 'src/docs/asciidocEpub'
 
         // TODO: We are setting this currently to fix a problem in asciidoctor-epub GEM.
         useIntermediateWorkDir()

--- a/jvm-epub/src/main/groovy/org/asciidoctor/gradle/jvm/epub/AsciidoctorJEpubPlugin.groovy
+++ b/jvm-epub/src/main/groovy/org/asciidoctor/gradle/jvm/epub/AsciidoctorJEpubPlugin.groovy
@@ -26,6 +26,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.ysb33r.grolifant.api.TaskProvider
 
+import static org.asciidoctor.gradle.base.AsciidoctorUtils.setConvention
+
 /** Provides additional conventions for building EPUBs.
  *
  * <ul>
@@ -53,8 +55,10 @@ class AsciidoctorJEpubPlugin implements Plugin<Project> {
                 void execute(AsciidoctorEpubTask task) {
                     task.group = AsciidoctorJBasePlugin.TASK_GROUP
                     task.description = 'Convert AsciiDoc files to EPUB3/KF8 formats'
-                    task.outputDir = { "${task.project.buildDir}/docs/asciidocEpub" }
-                    task.sourceDir = 'src/docs/asciidoc'
+                    setConvention(project, task.sourceDirProperty,
+                            project.layout.projectDirectory.dir('src/docs/asciidoc'))
+                    setConvention(task.outputDirProperty,
+                            task.project.layout.buildDirectory.dir('docs/asciidocEpub'))
                 }
             }
 

--- a/jvm-leanpub/src/main/groovy/org/asciidoctor/gradle/jvm/leanpub/AsciidoctorJLeanpubPlugin.groovy
+++ b/jvm-leanpub/src/main/groovy/org/asciidoctor/gradle/jvm/leanpub/AsciidoctorJLeanpubPlugin.groovy
@@ -23,6 +23,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.ysb33r.grolifant.api.TaskProvider
 
+import static org.asciidoctor.gradle.base.AsciidoctorUtils.setConvention
+
 /** Provides additional conventions for creating Leanpub markdown.
  *
  * <ul>
@@ -48,8 +50,10 @@ class AsciidoctorJLeanpubPlugin implements Plugin<Project> {
                 void execute(AsciidoctorLeanpubTask task) {
                     task.group = AsciidoctorJBasePlugin.TASK_GROUP
                     task.description = 'Convert AsciiDoc files to Leanpub-structured Markdown'
-                    task.outputDir = { "${task.project.buildDir}/docs/asciidocLeanpub" }
-                    task.sourceDir = 'src/docs/asciidoc'
+                    setConvention(task.project, task.sourceDirProperty,
+                            project.layout.projectDirectory.dir('src/docs/asciidoc'))
+                    setConvention(task.outputDirProperty,
+                            task.project.layout.buildDirectory.dir('docs/asciidocLeanpub'))
                 }
             }
 

--- a/jvm-pdf/src/main/groovy/org/asciidoctor/gradle/jvm/pdf/AsciidoctorJPdfPlugin.groovy
+++ b/jvm-pdf/src/main/groovy/org/asciidoctor/gradle/jvm/pdf/AsciidoctorJPdfPlugin.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
+import static org.asciidoctor.gradle.base.AsciidoctorUtils.setConvention
 import static org.ysb33r.grolifant.api.TaskProvider.registerTask
 
 /** Provides additional conventions for building PDFs.
@@ -37,7 +38,6 @@ import static org.ysb33r.grolifant.api.TaskProvider.registerTask
  */
 @CompileStatic
 class AsciidoctorJPdfPlugin implements Plugin<Project> {
-
     void apply(Project project) {
         project.with {
             apply plugin: AsciidoctorJBasePlugin
@@ -51,8 +51,9 @@ class AsciidoctorJPdfPlugin implements Plugin<Project> {
                     task.with {
                         group = AsciidoctorJBasePlugin.TASK_GROUP
                         description = 'Convert AsciiDoc files to PDF format'
-                        outputDir = { "${project.buildDir}/docs/asciidocPdf" }
-                        sourceDir = 'src/docs/asciidoc'
+                        setConvention(project, sourceDirProperty,
+                                project.layout.projectDirectory.dir('src/docs/asciidoc'))
+                        setConvention(outputDirProperty, project.layout.buildDirectory.dir('docs/asciidocPdf'))
                     }
                 }
             }

--- a/jvm-slides/src/main/groovy/org/asciidoctor/gradle/jvm/slides/AsciidoctorRevealJSPlugin.groovy
+++ b/jvm-slides/src/main/groovy/org/asciidoctor/gradle/jvm/slides/AsciidoctorRevealJSPlugin.groovy
@@ -21,6 +21,8 @@ import org.asciidoctor.gradle.jvm.gems.AsciidoctorGemSupportPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
+import static org.asciidoctor.gradle.base.AsciidoctorUtils.setConvention
+
 /** Adds an extension and task to create Reveal.js slides.
  *
  * @since 2.0
@@ -40,8 +42,8 @@ class AsciidoctorRevealJSPlugin implements Plugin<Project> {
 
         revealTask.with {
             dependsOn gemPrepare
-            outputDir = { "${project.buildDir}/docs/asciidocRevealJs" }
-            sourceDir = 'src/docs/asciidoc'
+            setConvention(project, sourceDirProperty, project.layout.projectDirectory.dir('src/docs/asciidoc'))
+            setConvention(outputDirProperty, project.layout.buildDirectory.dir('docs/asciidocRevealJs'))
         }
     }
 }

--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTask.groovy
@@ -26,6 +26,7 @@ import org.ysb33r.grolifant.api.FileUtils
 import javax.inject.Inject
 
 import static groovy.lang.Closure.DELEGATE_FIRST
+import static org.asciidoctor.gradle.base.AsciidoctorUtils.setConvention
 
 /** Standard generic task for converting Asciidoctor documents.
  *
@@ -86,8 +87,8 @@ class AsciidoctorTask extends AbstractAsciidoctorTask {
             folderName = "asciidoc${name.capitalize()}"
         }
         final String safeFolderName = FileUtils.toSafeFileName(folderName)
-        sourceDir = "src/docs/${folderName}"
-        outputDir = { project.file("${project.buildDir}/docs/${safeFolderName}") }
+        setConvention(project, sourceDirProperty, project.layout.projectDirectory.dir("src/docs/${folderName}"))
+        setConvention(outputDirProperty, project.layout.buildDirectory.dir("docs/${safeFolderName}"))
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/478.

This changes `AbstractAsciidoctorBaseTask` to use property objects for `sourceDir` and `outputDir` and use conventions to set up the default values (avoiding the ordering problem in the issue above).  Note that there is some byzantine logic around setting up the conventions due to all the flux with the Provider API between versions 4, 5, and 6.  This has mostly stabilized in 6.x, so as support is dropped for older Gradle versions, this logic should get simpler, too.

Note the removal of the default value in the constructor for `AsciidoctorEpubTask`.  As near as I can tell, that was virtually always being overwritten by the default value being set in `AsciidoctorJEpubPlugin`, so I removed the one in the task constructor.  If this was important in some scenario, we can look at ways to add it back, but it's kind of hard to reproduce the behavior with property objects and Gradle pre-5.1 (i.e. before `convention()` was introduced) so it was just easier to remove this.