### PR TITLE
Add baseDirFollowsSourceFile() to restore support for include directive with relative path

### DIFF
--- a/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
+++ b/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
@@ -20,6 +20,7 @@ import groovy.transform.CompileStatic
 import org.asciidoctor.gradle.base.basedir.BaseDirFollowsProject
 import org.asciidoctor.gradle.base.basedir.BaseDirFollowsRootProject
 import org.asciidoctor.gradle.base.basedir.BaseDirIsFixedPath
+import org.asciidoctor.gradle.base.basedir.BaseDirIsNull
 import org.asciidoctor.gradle.base.internal.Workspace
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
@@ -170,6 +171,9 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
             case BaseDirStrategy:
                 this.baseDir = (BaseDirStrategy) f
                 break
+            case null:
+                this.baseDir = BaseDirIsNull.INSTANCE
+                break
             default:
                 this.baseDir = new BaseDirIsFixedPath(project.providers.provider({
                     project.file(f)
@@ -210,6 +214,14 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
         this.baseDir = new BaseDirIsFixedPath(project.providers.provider({ AbstractAsciidoctorBaseTask task ->
             task.withIntermediateWorkDir ? task.intermediateWorkDir : task.sourceDir
         }.curry(this) as Callable<File>))
+    }
+
+    /** Sets the basedir to be the same directory as each individual source file.
+     *
+     * @since 3.0.0
+     */
+    void baseDirFollowsSourceFile() {
+        this.baseDir = BaseDirIsNull.INSTANCE
     }
 
     /** Configures sources.
@@ -1026,16 +1038,18 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
             throw new GradleException("outputDir has not been defined for task '${name}'")
         }
 
-        Path sourceRoot = sourceDir.toPath().root
-        Path baseRoot = languages.empty ? getBaseDir().toPath().root : getBaseDir(languages[0]).toPath().root
-        Path outputRoot = outputDir.toPath().root
+        Path baseRoot = languages.empty ? getBaseDir()?.toPath()?.root : getBaseDir(languages[0])?.toPath()?.root
+        if (baseRoot != null) {
+            Path sourceRoot = sourceDir.toPath().root
+            Path outputRoot = outputDir.toPath().root
 
-        if (sourceRoot != baseRoot || outputRoot != baseRoot) {
-            throw new AsciidoctorExecutionException(
-                "sourceDir, outputDir and baseDir needs to have the same root filesystem for ${engineName} to " +
-                    'function correctly. ' +
-                    'This is typically caused on Windows where everything is not on the same drive letter.'
-            )
+            if (sourceRoot != baseRoot || outputRoot != baseRoot) {
+                throw new AsciidoctorExecutionException(
+                        "sourceDir, outputDir and baseDir needs to have the same root filesystem for ${engineName} " +
+                                'to function correctly. ' +
+                                'This is typically caused on Windows where everything is not on the same drive letter.'
+                )
+            }
         }
     }
 

--- a/base/src/main/groovy/org/asciidoctor/gradle/base/basedir/BaseDirIsNull.groovy
+++ b/base/src/main/groovy/org/asciidoctor/gradle/base/basedir/BaseDirIsNull.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle.base.basedir
+
+import groovy.transform.CompileStatic
+import org.asciidoctor.gradle.base.BaseDirStrategy
+
+/** Strategy where base directory is null so that input file's parent directory gets used as base_dir
+ * in asciidoctor conversion
+ *
+ * @author Lari Hotari
+ *
+ * @since 3.0.0
+ */
+@CompileStatic
+class BaseDirIsNull implements BaseDirStrategy {
+    static final BaseDirIsNull INSTANCE = new BaseDirIsNull()
+
+    final File baseDir = null
+
+    @Override
+    File getBaseDir(String lang) {
+        null
+    }
+}

--- a/docs/src/docs/asciidoc/parts/common-task-configuration.adoc
+++ b/docs/src/docs/asciidoc/parts/common-task-configuration.adoc
@@ -10,6 +10,7 @@ attributes:: A shortcut for `asciidoctorj.attributes` and `asciidoctorjs.attribu
 baseDir:: Base directory for asciidoctor document conversion and root document inclusion.
   The base directory will be the project directory by default, but can be set to any other directory.
 baseDirFollowsSourceDir:: The base directory should be the same as the source directory even if the source directory is located within an intermediate working directory.
+baseDirFollowsSourceFile:: The base directory should be the same as the directory of each individual source file.
 baseDirIsProjectDir:: The base directory is always the current project directory.
 baseDirIsRootProjectDir:: The base directory is always the root project directory.
 configurations:: Specify additional configurations
@@ -204,11 +205,13 @@ asciidoctor {
     baseDirIsRootProjectDir() // <1>
     baseDirIsProjectDir() // <2>
     baseDirFollowsSourceDir() // <3>
+    baseDirFollowsSourceFile() // <4>
 }
 ----
 <1> The base directory is the root project directory.
 <2> The base directory is the current subproject directory.
 <3> The base directory will always the the same as the source directory. If an intermediate working directory is being used, the base directory will automatically point to that.
+<4> The base directory will be the same as the directory of each individual source file.
 
 === Docinfo processing
 

--- a/jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/RelativeIncludeFunctionalSpec.groovy
+++ b/jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/RelativeIncludeFunctionalSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle.jvm
+
+import org.asciidoctor.gradle.internal.FunctionalSpecification
+import spock.lang.Issue
+
+class RelativeIncludeFunctionalSpec extends FunctionalSpecification {
+    static final List DEFAULT_ARGS = ['asciidoctor', '-s']
+
+    void setup() {
+        createTestProject('relative-include')
+    }
+
+    @Issue('https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/454')
+    void 'Includes are relative in source sub directories'() {
+        given:
+        getJvmConvertGroovyBuildFile( '''
+        asciidoctor {
+            baseDirFollowsSourceFile()
+        }
+        ''')
+
+        when:
+        getGradleRunner(DEFAULT_ARGS).withDebug(true).build()
+
+        then:
+        new File(testProjectDir.root, 'build/docs/asciidoc/nested/sample.html').text
+                .contains('This is from _nested-include.adoc file.')
+    }
+}

--- a/jvm/src/intTest/projects/relative-include/src/docs/asciidoc/nested/_nested-include.adoc
+++ b/jvm/src/intTest/projects/relative-include/src/docs/asciidoc/nested/_nested-include.adoc
@@ -1,0 +1,1 @@
+This is from _nested-include.adoc file.

--- a/jvm/src/intTest/projects/relative-include/src/docs/asciidoc/nested/sample.adoc
+++ b/jvm/src/intTest/projects/relative-include/src/docs/asciidoc/nested/sample.adoc
@@ -1,0 +1,3 @@
+= Relative include in a source sub directory
+
+include::_nested-include.adoc[]

--- a/jvm/src/test/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskSpec.groovy
+++ b/jvm/src/test/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskSpec.groovy
@@ -122,6 +122,26 @@ class AsciidoctorTaskSpec extends Specification {
         task.baseDir == project.file("${project.buildDir}/tmp/${task.name}.intermediate")
     }
 
+    void 'Base directory can be null to follow source file'() {
+        when:
+        AsciidoctorTask task = asciidoctorTask {
+            baseDirFollowsSourceFile()
+        }
+
+        then:
+        task.baseDir == null
+    }
+
+    void 'Base directory can be set to null'() {
+        when:
+        AsciidoctorTask task = asciidoctorTask {
+            baseDir = null
+        }
+
+        then:
+        task.baseDir == null
+    }
+
     void "Allow setting of options via method"() {
         when:
         AsciidoctorTask task = asciidoctorTask {


### PR DESCRIPTION
- solves issue reported in #454 . `baseDirFollowsSourceDir()` doesn't work when there are sub directories in the source directory and the expectation is that include resolves the included file relatively from the source file location.

Works based on this behavior:
- `Options.BASEDIR` gets set to `file.parentFile` in `org.asciidoctor.gradle.remote.ExecutorBase#normalisedOptionsFor`
  when a null `baseDir` gets passed to the method: https://github.com/asciidoctor/asciidoctor-gradle-plugin/blob/952e76434adbf1806192c97e0e5db4a9a5f4eff3/jvm/src/main/groovy/org/asciidoctor/gradle/remote/ExecutorBase.groovy#L82

Asciidoctor's manual includes this explanation:
https://asciidoctor.org/docs/user-manual/#include-resolution
> The base directory defaults to the directory of the main document and can be overridden from the CLI or API)

Perhaps it should be possible to let Options.BASEDIR to be unset all the way to asciidoctor?