### PR TITLE
Fix bug in AbstractAsciidoctorTask#sources(java.lang.String...)

### DIFF
--- a/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/asciidoctor-gradle-jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -66,8 +66,10 @@ import static org.ysb33r.grolifant.api.FileUtils.filesFromCopySpec
 
 /** Base class for all AsciidoctorJ tasks.
  *
- * @since 2.0.0* @author Schalk W. Cronjé
+ * @since 2.0.0
+ * @author Schalk W. Cronjé
  * @author Manuel Prinz
+ * @author Lari Hotari
  */
 @SuppressWarnings(['MethodCount', 'ClassSize'])
 @CompileStatic
@@ -178,13 +180,13 @@ class AbstractAsciidoctorTask extends DefaultTask {
      * @param includePatterns ANT-style patterns for sources to include
      */
     void sources(String... includePatterns) {
-        new Action<PatternSet>() {
+        sources(new Action<PatternSet>() {
 
             @Override
             void execute(PatternSet patternSet) {
                 patternSet.include(includePatterns)
             }
-        }
+        })
     }
 
     /** Set fork options for {@link #JAVA_EXEC} and {@link #OUT_OF_PROCESS} modes.

--- a/asciidoctor-gradle-jvm/src/test/groovy/org/asciidoctor/gradle/jvm/BaseTaskPatternSpec.groovy
+++ b/asciidoctor-gradle-jvm/src/test/groovy/org/asciidoctor/gradle/jvm/BaseTaskPatternSpec.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle.jvm
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.util.PatternSet
+import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.workers.WorkerExecutor
+import spock.lang.Specification
+
+import javax.inject.Inject
+
+/**
+ * @author Lari Hotari
+ */
+class BaseTaskPatternSpec extends Specification {
+    Project project = ProjectBuilder.builder().build()
+
+    static class PatternSpecAsciidoctorTask extends AbstractAsciidoctorTask {
+        @Inject
+        PatternSpecAsciidoctorTask(WorkerExecutor we) {
+            super(we)
+        }
+
+        // method for accessing internal field "sourceDocumentPattern"
+        PatternSet getInternalSourceDocumentPattern() {
+            AbstractAsciidoctorTask.metaClass.getProperty(this, 'sourceDocumentPattern')
+        }
+    }
+
+    void "Should include patterns passed to sources method"() {
+        when:
+        def task1 = createTask('task') {
+            sources('myfile.adoc', 'otherfile.adoc')
+        }
+        then:
+        task1.internalSourceDocumentPattern.includes == ['myfile.adoc', 'otherfile.adoc'] as Set
+    }
+
+    private Task createTask(String name, Closure cfg) {
+        project.tasks.create(name: name, type: PatternSpecAsciidoctorTask).configure cfg
+    }
+}


### PR DESCRIPTION
- method was a no-op

- backport of #495 for development-3.x branch to development-2.0 branch