### PR TITLE
Allow slides and convert plugins to co-exist

### DIFF
--- a/jvm-slides/src/intTest/groovy/org/asciidoctor/gradle/jvm/slides/AsciidoctorSlidesAndConvertPluginsCoexistFunctionalSpec.groovy
+++ b/jvm-slides/src/intTest/groovy/org/asciidoctor/gradle/jvm/slides/AsciidoctorSlidesAndConvertPluginsCoexistFunctionalSpec.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle.jvm.slides
+
+import org.asciidoctor.gradle.jvm.slides.internal.FunctionalSpecification
+import org.gradle.testkit.runner.BuildResult
+
+/**
+ * @author Lari Hotari
+ */
+class AsciidoctorSlidesAndConvertPluginsCoexistFunctionalSpec extends FunctionalSpecification {
+    void setup() {
+        createTestProject('coexist')
+    }
+
+    void 'Run asciidoctor task when slides and convert plugin are used in the same project'() {
+        given:
+        createBuildFile()
+
+        when:
+        build('asciidoctor')
+
+        then:
+        verifyAll {
+            new File(testProjectDir.root, 'build/docs/asciidoc/sample.html').exists()
+        }
+    }
+
+    BuildResult build(String... targets) {
+        getGradleRunner(targets.toList() + ['-s']).build()
+    }
+
+    File createBuildFile(String extraContent = '') {
+        File buildFile = testProjectDir.newFile('build.gradle')
+        buildFile << """
+        plugins {
+            id 'org.asciidoctor.jvm.revealjs'
+            id 'org.asciidoctor.jvm.convert'
+        }
+
+        ${offlineRepositories}
+
+        repositories {
+            ruby.gems()
+        }
+
+        asciidoctorRevealJs {
+            sourceDir 'src/docs/slides'
+        }
+
+        ${extraContent}
+"""
+        buildFile
+    }
+}
+

--- a/jvm-slides/src/intTest/projects/coexist/src/docs/asciidoc/sample.asciidoc
+++ b/jvm-slides/src/intTest/projects/coexist/src/docs/asciidoc/sample.asciidoc
@@ -1,0 +1,24 @@
+Document Title
+==============
+Doc Writer <thedoc@asciidoctor.org>
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Section A
+
+*Section A* paragraph.
+
+=== Section A Subsection
+
+*Section A* 'subsection' paragraph.
+
+== Section B
+
+*Section B* paragraph.
+
+.Section B list
+* Item 1
+* Item 2
+* Item 3

--- a/jvm-slides/src/intTest/projects/coexist/src/docs/slides/revealjs.adoc
+++ b/jvm-slides/src/intTest/projects/coexist/src/docs/slides/revealjs.adoc
@@ -1,0 +1,7 @@
+= Title Slide
+
+== Slide One
+
+* Foo
+* Bar
+* World

--- a/jvm-slides/src/main/groovy/org/asciidoctor/gradle/jvm/slides/AsciidoctorJRevealJSTask.groovy
+++ b/jvm-slides/src/main/groovy/org/asciidoctor/gradle/jvm/slides/AsciidoctorJRevealJSTask.groovy
@@ -21,7 +21,6 @@ import org.asciidoctor.gradle.base.Transform
 import org.asciidoctor.gradle.base.slides.Profile
 import org.asciidoctor.gradle.base.slides.SlidesToExportAware
 import org.asciidoctor.gradle.jvm.AbstractAsciidoctorTask
-import org.asciidoctor.gradle.jvm.AsciidoctorJExtension
 import org.asciidoctor.gradle.jvm.gems.AsciidoctorGemPrepare
 import org.gradle.api.Action
 import org.gradle.api.file.CopySpec
@@ -70,8 +69,6 @@ class AsciidoctorJRevealJSTask extends AbstractAsciidoctorTask implements Slides
         configuredOutputOptions.backends = [BACKEND_NAME]
         copyAllResources()
         org.ysb33r.grolifant.api.TaskProvider<AsciidoctorGemPrepare> gemPrepare = taskByName(project, GEMPREP_TASK)
-
-        AsciidoctorJExtension asciidoctorj = project.extensions.getByType(AsciidoctorJExtension)
 
         asciidoctorj.with {
             requires(REVEALJS_GEM)


### PR DESCRIPTION
- fixes #464, #388

- fixes error "no such file to load -- asciidoctor-revealjs"
  - this error happened if asciidoctorGemsPrepare task hadn't been run
    before running asciidoctor task

- AsciidoctorJRevealJSTask registered the ruby module requirement of
  asciidoctor-revealjs to the project level AsciidoctorJExtension.
  Issue is fixed by using the task level AsciidoctorJExtension.