### PR TITLE
Add "clearSources()" method to base task

### DIFF
--- a/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
+++ b/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
@@ -284,6 +284,12 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
         })
     }
 
+    /** Clears existing sources patterns.
+     */
+    void clearSources() {
+        sourceDocumentPattern = null
+    }
+
     /** Clears any of the existing secondary soruces patterns.
      *
      * This should be used if none of the default patterns should be monitored.

--- a/base/src/test/groovy/org/asciidoctor/gradle/base/BaseTaskPatternSpec.groovy
+++ b/base/src/test/groovy/org/asciidoctor/gradle/base/BaseTaskPatternSpec.groovy
@@ -70,6 +70,29 @@ class BaseTaskPatternSpec extends Specification {
         task1.internalSourceDocumentPattern.includes == ['myfile.adoc', 'otherfile.adoc'] as Set
     }
 
+    void "Should support clearing configured patterns"() {
+        given:
+        def task = createTask('task') {
+            sources('myfile.adoc', 'otherfile.adoc')
+        }
+        when:
+        task.clearSources()
+        then:
+        task.internalSourceDocumentPattern == null
+    }
+
+    void "Should support replacing the configured patterns"() {
+        given:
+        def task = createTask('task') {
+            sources('myfile.adoc', 'otherfile.adoc')
+        }
+        when:
+        task.clearSources()
+        task.sources('myfile2.adoc', 'myfile3.adoc')
+        then:
+        task.internalSourceDocumentPattern.includes == ['myfile2.adoc', 'myfile3.adoc'] as Set
+    }
+
     private Task createTask(String name, Closure cfg) {
         project.tasks.create(name: name, type: PatternSpecAsciidoctorTask).configure cfg
     }


### PR DESCRIPTION
- there is already "clearSecondarySources()" so adding this method would
  make it symmetrical