### PR TITLE
Don't add revnumber attr when project.version is unspecified

### DIFF
--- a/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
+++ b/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
+import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.DirectoryProperty
@@ -770,7 +771,7 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
             'gradle-project-name': (Object) project.name
         ]
 
-        if (project.version != null) {
+        if (project.version != null && project.version.toString() != Project.DEFAULT_VERSION) {
             attrs.put('revnumber', (Object) project.version)
         }
 

--- a/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
+++ b/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
@@ -1015,7 +1015,7 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
         Map<String, Object> defaultAttributes,
         Optional<String> lang
     ) {
-        Set<String> userDefinedAttrKeys = seedAttributes.keySet()
+        Set<String> userDefinedAttrKeys = trimOverridableAttributeNotation(seedAttributes.keySet())
 
         Map<String, Object> defaultAttrs = defaultAttributes.findAll { k, v ->
             !userDefinedAttrKeys.contains(k)
@@ -1028,6 +1028,12 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
         }
 
         defaultAttrs
+    }
+
+    private Set<String> trimOverridableAttributeNotation(Set<String> attributeKeys) {
+        // remove possible trailing '@' character that is used to encode that the attribute can be overridden
+        // in the document itself
+        Transform.toSet(attributeKeys) { k -> k - ~/@$/ }
     }
 
     /** Evaluates a map of items potentially containing providers.

--- a/jvm/src/test/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskSpec.groovy
+++ b/jvm/src/test/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskSpec.groovy
@@ -516,6 +516,33 @@ class AsciidoctorTaskSpec extends Specification {
         then:
         task.sampleExecutorConfiguration.attributes.'revnumber@' == null
     }
+
+    void "should allow overriding revnumber@ attribute"() {
+        when:
+        project.version = '1.2.3'
+        def task = project.tasks.create(name: ASCIIDOCTOR, type: ExecutorConfigurationInspectingAsciidoctorTask)
+                .configure {
+                    attributes('revnumber@': 'x.y.z')
+                }
+
+        then:
+        task.sampleExecutorConfiguration.attributes.'revnumber@' == 'x.y.z'
+    }
+
+    void "should not set the revnumber@ attribute when revnumber attribute is set"() {
+        when:
+        project.version = '1.2.3'
+        def task = project.tasks.create(name: ASCIIDOCTOR, type: ExecutorConfigurationInspectingAsciidoctorTask)
+                .configure {
+                    attributes('revnumber': 'x.y.z')
+                }
+
+        then:
+        with(task.sampleExecutorConfiguration) {
+            attributes.'revnumber@' == null
+            attributes.'revnumber' == 'x.y.z'
+        }
+    }
 }
 
 class ExecutorConfigurationInspectingAsciidoctorTask extends AsciidoctorTask {


### PR DESCRIPTION
- Fixes #329
- project.version defaults to 'unspecified' in Gradle
- fix attempt was previously made in https://github.com/asciidoctor/asciidoctor-gradle-plugin/pull/337/commits/eb75b4972eb50e9c29e6a97e34c1b75a58bed95c, but that didn't check for `Project.DEFAULT_VERSION` (which is `unspecified`). 