### PR TITLE
Allow actions to be executed for asciidoctorj detached configuration

### DIFF
--- a/docs/src/docs/asciidoc/appendix/tips-and-tricks.adoc
+++ b/docs/src/docs/asciidoc/appendix/tips-and-tricks.adoc
@@ -74,3 +74,11 @@ asciidoctorPdf {
   }
 }
 ----
+
+=== Resolving AsciidoctorJ dependencies against a specific repository
+
+
+[source,groovy]
+----
+include::{plugin-jvm}/test/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJExtensionSpec.groovy[tags=restrict-repository,indent=0]
+----

--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJExtension.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJExtension.groovy
@@ -77,6 +77,7 @@ class AsciidoctorJExtension extends AbstractImplementationEngineExtension {
     private final List<Object> asciidoctorExtensions = []
     private final List<Object> gemPaths = []
     private final List<Action<ResolutionStrategy>> resolutionsStrategies = []
+    private final List<Action<Configuration>> configurationCallbacks = []
     private final List<Object> warningsAsErrors = []
     private final AsciidoctorJModules modules
 
@@ -85,6 +86,8 @@ class AsciidoctorJExtension extends AbstractImplementationEngineExtension {
     private boolean onlyTaskExtensions = false
     private boolean onlyTaskGems = false
     private boolean onlyTaskWarnings = false
+    private boolean onlyTaskResolutionStrategies = false
+    private boolean onlyTaskConfigurationCallbacks = false
 
     private LogLevel logLevel
 
@@ -487,10 +490,39 @@ class AsciidoctorJExtension extends AbstractImplementationEngineExtension {
        end::extension-property[]
        ------------------------- */
 
+    /** List of resolution strategies that will be applied to the Asciidoctorj group of dependencies.
+     *
+     * If called on a task, the project extensions's resolution strategies are returned ahead of the task-specific
+     * resolution strategies.
+     *
+     * If called on a task where {@link #clearResolutionStrategies} was called previously, only the task-specifc
+     * resolution strategies are returned.
+     *
+     * @return List of actions. Can be empty, but never {@code null}.
+     *
+     * @since 3.1.0
+     */
+    Iterable<Action<ResolutionStrategy>> getResolutionStrategies() {
+        if (task) {
+            if (onlyTaskResolutionStrategies) {
+                this.resolutionsStrategies
+            } else {
+                extFromProject.resolutionsStrategies + this.resolutionsStrategies
+            }
+        } else {
+            this.resolutionsStrategies
+        }
+    }
+
     /** Clears the current list of resolution strategies.
      *
+     * If called on a task extension, all subsequent strategies added to the project extension will be ignored
+     * in task context.
      */
     void clearResolutionStrategies() {
+        if (task) {
+            onlyTaskResolutionStrategies = true
+        }
         this.resolutionsStrategies.clear()
     }
 
@@ -508,6 +540,72 @@ class AsciidoctorJExtension extends AbstractImplementationEngineExtension {
      */
     void resolutionStrategy(@DelegatesTo(ResolutionStrategy) Closure strategy) {
         this.resolutionsStrategies.add(strategy as Action<ResolutionStrategy>)
+    }
+
+    /* -------------------------
+       tag::extension-property[]
+        onConfiguration:: Additional actions to be performed when the detached configuration for the
+        {asciidoctorj-name} is created.
+       end::extension-property[]
+       ------------------------- */
+
+    /** List of callbacks that will be applied whent he asciidoctorj-related detached configuration is created.
+     *
+     * If called on a task, the project extensions's callbacks are returned ahead of the task-specific
+     * callbacks.
+     *
+     * If called on a task where {@link #clearConfigurationCallbacks} was called previously, only the task-specifc
+     * callbacks are returned.
+     *
+     * @return List of callbacks. Can be empty, but never {@code null}.
+     *
+     * @since 3.1.0
+     */
+    Iterable<Action<Configuration>> getConfigurationCallbacks() {
+        if (task) {
+            if (onlyTaskConfigurationCallbacks) {
+                this.configurationCallbacks
+            } else {
+                extFromProject.configurationCallbacks + this.configurationCallbacks
+            }
+        } else {
+            this.configurationCallbacks
+        }
+    }
+
+    /** Clears the current list of resolution strategies.
+     *
+     * If called on a task extension, all subsequent callbacks added to the project extension will be ignored
+     * in task context.
+     *
+     * @since 3.1.0
+     */
+    void clearConfigurationCallbacks() {
+        if (task) {
+            onlyTaskConfigurationCallbacks = true
+        }
+
+        this.configurationCallbacks.clear()
+    }
+
+    /** Adds a callback for when the asciidoctorj-related detached configuration is created.
+     *
+     * @param callback The detached configuration is passed to this {@code Action}.
+     *
+     * @since 3.1.0
+     */
+    void onConfiguration(Action<Configuration> callback) {
+        this.configurationCallbacks.add(callback)
+    }
+
+    /** Adds a callback for when the asciidoctorj-related detached configuration is created.
+     *
+     * @param callback The detached configuration is passed to this closure}.
+     *
+     * @since 3.1.0
+     */
+    void onConfiguration(@DelegatesTo(Configuration) Closure callback) {
+        this.configurationCallbacks.add(callback as Action<Configuration>)
     }
 
     /* -------------------------
@@ -611,8 +709,12 @@ class AsciidoctorJExtension extends AbstractImplementationEngineExtension {
             }
         }
 
-        resolutionsStrategies.each {
+        resolutionStrategies.each {
             configuration.resolutionStrategy(it)
+        }
+
+        configurationCallbacks.each {
+            it.execute(configuration)
         }
 
         configuration

--- a/jvm/src/test/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJExtensionSpec.groovy
+++ b/jvm/src/test/groovy/org/asciidoctor/gradle/jvm/AsciidoctorJExtensionSpec.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle.jvm
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+/**
+ * @author Schalk W. Cronjé
+ */
+
+class AsciidoctorJExtensionSpec extends Specification {
+
+    Project project = ProjectBuilder.builder().withName('test').build()
+    AsciidoctorJExtension asciidoctorj
+
+    void setup() {
+        project.allprojects {
+            apply plugin: 'org.asciidoctor.jvm.base'
+        }
+
+        asciidoctorj = project.extensions.getByType(AsciidoctorJExtension)
+    }
+
+    void 'Add a callback to configuration'() {
+        setup:
+        boolean callbackCalled = false
+        asciidoctorj.onConfiguration { Configuration cfg ->
+            callbackCalled = true
+        }
+
+        when:
+        asciidoctorj.configuration
+
+        then:
+        callbackCalled
+    }
+
+    void 'Configure a repository for callback'() {
+        project.allprojects {
+            // tag::restrict-repository[]
+            repositories {
+                maven {
+                    name = 'asciidoctorj'
+                    url = 'https://some.repo.example'
+                }
+            }
+
+            asciidoctorj {
+                onConfiguration { cfg ->
+                    repositories.getByName('asciidoctorj').mavenContent { descriptor ->
+                        descriptor.onlyForConfigurations(cfg.name)
+                    }
+                }
+            }
+            // end::restrict-repository[]
+        }
+
+        when:
+        project.evaluate()
+        asciidoctorj.configuration
+
+        then:
+        noExceptionThrown()
+    }
+}


### PR DESCRIPTION
Allow actions to be executed when Asciidoctorj detached configuration is created (#511)

Build script authors can registers additional actions to be executed every time the configuration
that holds the asciidcotrj dependencies, is created. This is done via the onConfiguration call.
Actions can be task-specific and can even be completely decoupled from the project actions. If not,
then project actions will be executed before task-specific actions.