### PR TITLE
Added Kotlin DSL example to 'Adding Custom Extensions'

### DIFF
--- a/docs/src/docs/asciidoc/parts/asciidoctorj-custom-extensions.adoc
+++ b/docs/src/docs/asciidoc/parts/asciidoctorj-custom-extensions.adoc
@@ -9,7 +9,7 @@ for that matter. Now with the 2.0.0 you have even more flexibility in that exten
 This is the most versatile option, as it allows you to reuse the same extension in different projects. An external library
 is just like any other Java/Groovy project. You simply define a dependency using the `asciidoctor` configuration.
 
-[source,groovy]
+[source,groovy,role="primary"]
 .build.gradle
 ----
 configurations {
@@ -24,6 +24,21 @@ asciidoctor {
     configurations 'asciidoctorExt'
 }
 ----
+
+[source,kotlin,role="secondary"]
+.build.gradle.kts
+----
+val asciidoctorExt by configurations.creating
+
+dependencies {
+    asciidoctorExt("com.acme:asciidoctor-extensions:x.y.z")
+}
+
+tasks.withType<AsciidoctorTask> {
+   configurations("asciidoctorExt")
+}
+----
+
 
 === As Project Dependency
 


### PR DESCRIPTION
This adds a Kotlin DSL example to the section on Adding Custom Extensions > [As External Library](https://asciidoctor.github.io/asciidoctor-gradle-plugin/development-3.x/user-guide/#_as_external_library) in the Asciidoctor Gradle Plugin Suite guide.