### PR TITLE
Handle different variants of Guava

### DIFF
--- a/jvm/src/main/groovy/org/asciidoctor/gradle/internal/JavaExecUtils.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/internal/JavaExecUtils.groovy
@@ -129,7 +129,7 @@ class JavaExecUtils {
     private static FilenameFilter internalGuavaPattern() {
         Pattern filter
         if (GradleVersion.current() >= GradleVersion.version('5.0')) {
-            filter = ~/guava-([\d.]+)-android.jar/
+            filter = ~/guava-([\d.]+)-[jre|android]+.jar/
         } else {
             filter = ~/guava-jdk5-([\d.]+).jar/
         }

--- a/jvm/src/test/groovy/org/asciidoctor/gradle/internal/JavaExecUtilsSpec.groovy
+++ b/jvm/src/test/groovy/org/asciidoctor/gradle/internal/JavaExecUtilsSpec.groovy
@@ -55,4 +55,20 @@ class JavaExecUtilsSpec extends Specification {
         def e = thrown(JavaExecUtils.InternalGuavaLocationException)
         e.message.contains('Found more than one Guava JAR in the Gradle distribution')
     }
+
+    void 'detect jre variant of guava'() {
+        setup:
+        def gradle = Stub(Gradle)
+        gradle.gradleHomeDir >> temporaryFolder.root
+        new File(temporaryFolder.root, 'lib').mkdirs()
+        new File(temporaryFolder.root, 'lib/guavasomething.jar')
+        def guavaJar = new File(temporaryFolder.root, 'lib/guava-30.0-jre.jar')
+        guavaJar.text = ''
+
+        when:
+        def location = JavaExecUtils.getInternalGuavaLocation(gradle)
+
+        then:
+        location == guavaJar
+    }
 }


### PR DESCRIPTION
Avoid hardcoding which variant of Guava Gradle is going to ship with. This allows Gradle to use other variants without breaking the asciidoctor plugin.