### PR TITLE
Fix task property annotation problems

### DIFF
--- a/asciidoctoreditorconfig/src/main/groovy/org/asciidoctor/gradle/editorconfig/AsciidoctorEditorConfigGenerator.groovy
+++ b/asciidoctoreditorconfig/src/main/groovy/org/asciidoctor/gradle/editorconfig/AsciidoctorEditorConfigGenerator.groovy
@@ -23,6 +23,8 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 import java.util.concurrent.Callable
@@ -114,6 +116,7 @@ class AsciidoctorEditorConfigGenerator extends DefaultTask {
      * @return List of file providers
      */
     @InputFiles
+    @PathSensitive(PathSensitivity.NONE)
     List<Provider<File>> getAdditionalFileProviders() {
         this.fileProviders
     }

--- a/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
+++ b/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
@@ -85,9 +85,7 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
     private PatternSet intermediateArtifactPattern
     private final List<String> languages = []
     private final Map<String, CopySpec> languageResources = [:]
-
-    @Nested
-    protected final OutputOptions configuredOutputOptions = new OutputOptions()
+    private final OutputOptions configuredOutputOptions = new OutputOptions()
 
     /** Logs documents as they are converted
      *
@@ -636,6 +634,11 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
             .withPathSensitivity(RELATIVE)
         this.srcDir = createDirectoryProperty(project)
         this.outDir = createDirectoryProperty(project)
+    }
+
+    @Nested
+    protected OutputOptions getConfiguredOutputOptions() {
+        configuredOutputOptions
     }
 
     /** Gets the CopySpec for additional resources.

--- a/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
+++ b/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
@@ -648,7 +648,6 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
      * @param lang Language to to apply to or empty for no-language support.
      * @return A{@link CopySpec}. Never {@code null}.
      */
-    @Internal
     protected CopySpec getResourceCopySpec(Optional<String> lang) {
         this.resourceCopy ?: getDefaultResourceCopySpec(lang)
     }
@@ -661,7 +660,6 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
      * @return A{@link CopySpec}. Never {@code null}.
      */
     @CompileDynamic
-    @Internal
     protected CopySpec getDefaultResourceCopySpec(Optional<String> lang) {
         project.copySpec {
             from(lang.present ? new File(sourceDir, lang.get()) : sourceDir) {

--- a/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
+++ b/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
@@ -606,7 +606,6 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
      *
      * @param m Map with new options
      */
-    @Input
     abstract void attributes(Map<String, Object> m)
 
     /** Shortcut method to access additional providers of attributes.

--- a/base/src/main/java/org/asciidoctor/gradle/base/slides/SlidesToExportAware.java
+++ b/base/src/main/java/org/asciidoctor/gradle/base/slides/SlidesToExportAware.java
@@ -15,8 +15,8 @@
  */
 package org.asciidoctor.gradle.base.slides;
 
-import groovy.transform.Internal;
 import org.gradle.api.Task;
+import org.gradle.api.tasks.Internal;
 
 /** For tasks types that creates slides and can be auto-recognised
  * for specific slide-to-pdf converters when such plugins are applied.
@@ -24,5 +24,6 @@ import org.gradle.api.Task;
  * @since 2.2.0
  */
 public interface SlidesToExportAware extends Task {
+    @Internal
     Profile getProfile();
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ jsoupVersion           = 1.11.2
 spockVersion           = 1.3-groovy-2.5
 grolifantVersion       = 0.16.1
 jacocoVersion          = 0.8.1
-jrubyGradleVersion     = 2.0.0
+jrubyGradleVersion     = 2.0.1
 codenarcVersion        = 1.3
 nodejsGradleVersion    = 0.6.2
 

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -176,6 +176,10 @@ publishing {
     }
 }
 
+tasks.withType(ValidateTaskProperties) { validateTaskProperties ->
+    validateTaskProperties.failOnWarning = true
+    validateTaskProperties.enableStricterValidation = true
+}
 
 //bintray {
 //    user = bintrayUsername

--- a/jvm-leanpub/src/main/groovy/org/asciidoctor/gradle/jvm/leanpub/DropboxCopyTask.groovy
+++ b/jvm-leanpub/src/main/groovy/org/asciidoctor/gradle/jvm/leanpub/DropboxCopyTask.groovy
@@ -23,6 +23,8 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.ysb33r.grolifant.api.StringUtils
 
@@ -91,6 +93,7 @@ class DropboxCopyTask extends DefaultTask {
      * @return Directory containing generated Leanpub Markuva or Markdown content.
      */
     @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
     File getSourceDir() {
         project.file(this.sourceDir)
     }

--- a/jvm-pdf/src/main/groovy/org/asciidoctor/gradle/jvm/pdf/AsciidoctorPdfTask.groovy
+++ b/jvm-pdf/src/main/groovy/org/asciidoctor/gradle/jvm/pdf/AsciidoctorPdfTask.groovy
@@ -23,6 +23,7 @@ import org.asciidoctor.gradle.jvm.AsciidoctorJExtension
 import org.gradle.api.Project
 import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.file.FileCollection
+import org.gradle.api.model.ReplacedBy
 @java.lang.SuppressWarnings('NoWildcardImports')
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.util.PatternSet
@@ -60,7 +61,7 @@ class AsciidoctorPdfTask extends AbstractAsciidoctorTask {
      * @throws {@link PdfFontDirException} if there are either multiple directories or no directory for pdf font
      * */
     @Deprecated
-    @Internal
+    @ReplacedBy('getFontsDirs')
     File getFontsDir() {
         if (this.fontDirs.size() > 1) {
             throw new PdfFontDirException('There is more than 1 file in the fonts directory')

--- a/slides-export/src/main/groovy/org/asciidoctor/gradle/slides/export/base/AbstractExportBaseTask.groovy
+++ b/slides-export/src/main/groovy/org/asciidoctor/gradle/slides/export/base/AbstractExportBaseTask.groovy
@@ -127,7 +127,6 @@ abstract class AbstractExportBaseTask extends DefaultTask {
      * @return Outpur directory
      */
     @OutputDirectory
-    @PathSensitive(RELATIVE)
     File getOutputDir() {
         project.file(this.outputDir)
     }


### PR DESCRIPTION
This PR fixes some validation problems with tasks in the plugin that will cause any build using the plugin to fail with Gradle 7.0. It also enables strict validation during the build, so any new validation problems introduced will make the build fail.

The particular problems fixed by this PR are:

```text
1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':asciidoctoreditorconfig:validateTaskProperties'.
> Task property validation failed. See https://docs.gradle.org/5.5.1/userguide/more_about_tasks.html#sec:task_input_output_annotations for more information on how to annotate task properties.
   > Warning: Type 'org.asciidoctor.gradle.editorconfig.AsciidoctorEditorConfigGenerator': property 'additionalFileProviders' is missing a normalization annotation, defaulting to PathSensitivity.ABSOLUTE.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':asciidoctor-gradle-slides-export:validateTaskProperties'.
> Task property validation failed. See https://docs.gradle.org/5.5.1/userguide/more_about_tasks.html#sec:task_input_output_annotations for more information on how to annotate task properties.
   > Warning: Type 'org.asciidoctor.gradle.slides.export.base.AbstractExportBaseTask': property 'outputDir' is annotated with @PathSensitive that is not allowed for @OutputDirectory properties.
   > Warning: Type 'org.asciidoctor.gradle.slides.export.decktape.DeckTapeTask': property 'outputDir' is annotated with @PathSensitive that is not allowed for @OutputDirectory properties.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
==============================================================================

3: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':asciidoctor-gradle-jvm-pdf:validateTaskProperties'.
> Task property validation failed. See https://docs.gradle.org/5.5.1/userguide/more_about_tasks.html#sec:task_input_output_annotations for more information on how to annotate task properties.
   > Warning: Type 'org.asciidoctor.gradle.jvm.pdf.AsciidoctorPdfTask': property 'fontsDir' is not annotated with an input or output annotation.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
==============================================================================

4: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':asciidoctor-gradle-jvm-leanpub:validateTaskProperties'.
> Task property validation failed. See https://docs.gradle.org/5.5.1/userguide/more_about_tasks.html#sec:task_input_output_annotations for more information on how to annotate task properties.
   > Warning: Type 'org.asciidoctor.gradle.jvm.leanpub.DropboxCopyTask': property 'sourceDir' is missing a normalization annotation, defaulting to PathSensitivity.ABSOLUTE.
```

Also note that there are some validation warnings in the JRuby plugin that this plugin depends on. These warnings are fixed in https://github.com/jruby-gradle/jruby-gradle-plugin/pull/419. Once the JRuby plugin PR is merged, the dependency in the Asciidoctor plugin needs to be bumped in order to make this plugin fully compatible with Gradle 7.0.