### PR TITLE
Ensure consistent ordering in Sets returned from `Transform.toSet()`

### DIFF
--- a/base/src/main/groovy/org/asciidoctor/gradle/base/Transform.groovy
+++ b/base/src/main/groovy/org/asciidoctor/gradle/base/Transform.groovy
@@ -31,10 +31,10 @@ class Transform {
     }
 
     static <I,O> Set<O> toSet(final Collection<I> collection, Function<I,O> tx ) {
-        collection.stream().map(tx).collect(Collectors.toSet())
+        collection.stream().map(tx).collect(Collectors.toCollection { new LinkedHashSet<O>() })
     }
 
     static <I,O> Set<O> toSet(final Iterable<I> collection, Function<I,O> tx ) {
-        collection.toList().stream().map(tx).collect(Collectors.toSet())
+        collection.toList().stream().map(tx).collect(Collectors.toCollection { new LinkedHashSet<O>() })
     }
 }


### PR DESCRIPTION
The `Transform.toSet()` methods return a HashSet instance that has non-deterministic ordering.
These methods are used to construct a number of task inputs and outputs, including:
- `AbstractAsciidoctorBaseTask.getBackendOutputDirectories`
- `AsciidoctorEpubTask.ebookFormats`
- `AbstractAsciidoctorTask.configurations`

It is important that task inputs and outputs are consistent to ensure Gradle can correctly determine if a task is up-to-date.

These are not just theoretical issues, as reported by #591.
When `docExtensions` are added as Closures to `asciidoctorj`, the `AbstractAsciiDoctorTask` adds a number of Gradle/Groovy dependencies to the Classpath used to invoke Asciidoctor. Since `AbstractAsciidoctorTask.configurations` is registered as a task input, this inconsistent classpath ordering leads to cache misses and tasks not being considered `UP-TO-DATE`, resulting in unneccessary re-execution.

This change simply changes `Transform.toSet()` methods to return a `LinkedHashSet`, ensuring consistent iteration order for the returned Sets.

Fixes #591