### PR TITLE
Add name declarations to unnamed input properties

### DIFF
--- a/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
+++ b/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
@@ -630,6 +630,7 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
     protected AbstractAsciidoctorBaseTask() {
         super()
         inputs.files { filesFromCopySpec(getResourceCopySpec(Optional.empty())) }
+            .withPropertyName('resources')
             .withPathSensitivity(RELATIVE)
         this.srcDir = createDirectoryProperty(project)
         this.outDir = createDirectoryProperty(project)

--- a/jvm-slides/src/main/groovy/org/asciidoctor/gradle/jvm/slides/AsciidoctorJRevealJSTask.groovy
+++ b/jvm-slides/src/main/groovy/org/asciidoctor/gradle/jvm/slides/AsciidoctorJRevealJSTask.groovy
@@ -75,9 +75,12 @@ class AsciidoctorJRevealJSTask extends AbstractAsciidoctorTask implements Slides
             gemPaths { gemPrepare.get().outputDir }
         }
 
-        inputs.file( { RevealJSOptions opt -> opt.highlightJsThemeIfFile }.curry(this.revealjsOptions) ).optional()
-        inputs.file( { RevealJSOptions opt -> opt.parallaxBackgroundImageIfFile }.
-                curry(this.revealjsOptions) ).optional()
+        inputs.file( { RevealJSOptions opt -> opt.highlightJsThemeIfFile }.curry(this.revealjsOptions) )
+            .withPropertyName('highlightJsTheme')
+            .optional()
+        inputs.file( { RevealJSOptions opt -> opt.parallaxBackgroundImageIfFile }.curry(this.revealjsOptions) )
+            .withPropertyName('parallaxBackgroundImage')
+            .optional()
     }
 
     /** Options for Reveal.JS slides.

--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -365,6 +365,7 @@ class AbstractAsciidoctorTask extends AbstractAsciidoctorBaseTask {
             .curry(this.asciidoctorj)
 
         inputs.files { asciidoctorj.gemPaths }
+            .withPropertyName('gemPaths')
             .withPathSensitivity(RELATIVE)
     }
 


### PR DESCRIPTION
This changes adds name declarations in several places where input properties were being declared without property names.  Without property names, inputs declared with the runtime API are assigned names like `$1` which are unhelpful while troubleshooting.