### PR TITLE
Fix typo

### DIFF
--- a/docs/src/docs/asciidoc/parts/common-task-configuration.adoc
+++ b/docs/src/docs/asciidoc/parts/common-task-configuration.adoc
@@ -21,7 +21,7 @@ copyResourcesOnlyIf:: Only copy resources if the backend matches the listed back
 languages:: Invoke source language support but specifying one or more languages.
 inProcess:: Specifies whether Asciidoctor conversions should be run in-process or out-of-process. Default: `true` (in-process).
 logDocuments:: Specifies if documents being processed should be logged on console. Type: boolean. Default: `false`.
-options:: A shortcut to`asciidoctorj.options`.
+options:: A shortcut to `asciidoctorj.options`.
 outputDir:: where generated docs go.
   Use either `outputDir path`, `setOutputDir path` or `outputDir=path`
   Type: File, but any object convertible with `project.file` can be passed.


### PR DESCRIPTION
The previous version [got rendered](https://asciidoctor.github.io/asciidoctor-gradle-plugin/development-3.x/user-guide/#_task_configuration) like this:

> A shortcut toàsciidoctorj.options`.

