### PR TITLE
Use the official gradle/gradle-build-action

### DIFF
--- a/.github/actions/setup-jdk/action.yml
+++ b/.github/actions/setup-jdk/action.yml
@@ -1,0 +1,15 @@
+name: Setup JDKs
+description: Sets up JDKs
+inputs:
+  java-version:
+    default: '11'
+    required: false
+    description: Java version to install (defaults to 11)
+runs:
+    using: "composite"
+    steps:
+        -   name: 'Set up JDK 11'
+            uses: actions/setup-java@v2
+            with:
+                distribution: 'temurin'
+                java-version: {{ inputs.additional-java-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,56 +4,32 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-java@v1
+      - uses: actions/checkout@v2
         with:
-          java-version: 11
-      # Cache
-      - name: Cache .gradle/caches
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle-cache-
-      - name: Cache .gradle/wrapper
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle-wrapper-
+          fetch-depth: 1
+      - uses: ./.github/actions/setup-jdks
       # Licensing
       - name: Licensing
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
+          # cache options only count for the first invocation
+          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
           arguments: --console=plain -S license
       # Coding style
       - name: Coding style
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --console=plain -S codenarcAll
   build-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
-        # use a short path to avoid exceeding the path limit on Windows... sigh
+      - uses: actions/checkout@v2
         with:
+          # Codecov needs fetch-depth > 1
+          fetch-depth: 2
+          # use a short path to avoid exceeding the path limit on Windows... sigh
           path: 'w'
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 11
-      # Cache
-      - name: Cache .gradle/caches
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle-cache-
-      - name: Cache .gradle/wrapper
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle-wrapper-
+      - uses: ./.github/actions/setup-jdks
       - name: Cache offline repository
         uses: actions/cache@v1
         with:
@@ -62,29 +38,26 @@ jobs:
           restore-keys: ${{ runner.os }}-offline-repo-
       # Build
       - name: Build offline repository
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
+          # cache options only count for the first invocation
+          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
           arguments: --console=plain --no-build-cache :testfixtures-offline-repo:buildOfflineRepositories
       - name: Build
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --console=plain --warning-mode=all -s clean assemble
       # Test
       - name: Test
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: --console=plain --warning-mode=all -s check --no-parallel -Djava.net.preferIPv4Stack=true -x gradleTest --scan
       # Documentation
       - name: Documentation
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           build-root-directory: docs
           arguments: asciidoctor
-      # Stop gradlew to avoid locking issues
-      - name: Cleanup
-        uses: eskatos/gradle-command-action@v1
-        with:
-          arguments: --stop
   build:
     strategy:
       matrix:
@@ -92,23 +65,14 @@ jobs:
         java: [ 8, 11 ]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-java@v1
+    - uses: actions/checkout@v2
+      with:
+        # Codecov needs fetch-depth > 1
+        fetch-depth: 2
+    - uses: ./.github/actions/setup-jdks
       with:
         java-version: ${{ matrix.java }}
     # Cache
-    - name: Cache .gradle/caches
-      uses: actions/cache@v1
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle-cache-
-    - name: Cache .gradle/wrapper
-      uses: actions/cache@v1
-      with:
-        path: ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle-wrapper-
     - name: Cache offline repository
       uses: actions/cache@v1
       with:
@@ -116,25 +80,27 @@ jobs:
         key: ${{ runner.os }}-offline-repo-${{ hashFiles('module-versions.properties') }}
         restore-keys: ${{ runner.os }}-offline-repo-
     - name: Build offline repository
-      uses: eskatos/gradle-command-action@v1
+      uses: gradle/gradle-build-action@v2
       with:
+        # cache options only count for the first invocation
+        cache-read-only: ${{ github.ref != 'refs/heads/master' }}
         arguments: --console=plain --no-build-cache :testfixtures-offline-repo:buildOfflineRepositories
     # Build
     - name: Build
-      uses: eskatos/gradle-command-action@v1
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: -i -S --console=plain --no-build-cache assemble
     # Integration tests
     - name: Integration tests (without slides)
-      uses: eskatos/gradle-command-action@v1
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: -i -s --console=plain --no-build-cache test intTest remoteTest -x asciidoctor-gradle-slides-export:intTest -x asciidoctor-gradle-jvm-slides:intTest
     - name: Integration tests (slides only)
-      uses: eskatos/gradle-command-action@v1
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: -i -s --console=plain --no-build-cache test asciidoctor-gradle-jvm-slides:intTest asciidoctor-gradle-slides-export:intTest
     # Gradle tests
     - name: Gradle tests
-      uses: eskatos/gradle-command-action@v1
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: -i -s --console=plain --no-build-cache gradleTest


### PR DESCRIPTION
it already includes smart caching of the gradle home files,
so remove manual caching for that.
Extract setup jdk logic into a local workflow snippet.

Update actions/checkout to v2 and use fetch-depth