### PR TITLE
Support removal of main property in Gradle 8.0

### DIFF
--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -579,7 +579,7 @@ class AbstractAsciidoctorTask extends AbstractAsciidoctorBaseTask {
                 configureForkOptions(jes)
                 logger.debug "Running AsciidoctorJ instance with environment: ${jes.environment}"
                 jes.with {
-                    main = AsciidoctorJavaExec.canonicalName
+                    setExecClass(jes, AsciidoctorJavaExec.canonicalName)
                     classpath = javaExecClasspath
                     args execConfigurationData.absolutePath
                 }
@@ -592,6 +592,19 @@ class AbstractAsciidoctorTask extends AbstractAsciidoctorBaseTask {
         }
 
         executorConfigurations
+    }
+
+    /** The main property will be removed in Gradle 8.0 and replaced by the mainClass property.
+     *
+     * Attempt to use the main property, and if the method doesn't exist try the replacement.
+     */
+    @CompileDynamic
+    private void setExecClass(JavaExecSpec jes, String execClass) {
+        try {
+            jes.main = execClass
+        } catch (NoSuchMethodError e) {
+            jes.mainClass = execClass
+        }
     }
 
     private void copyResourcesByBackend(


### PR DESCRIPTION
- The main property is going to be replaced by mainClass in the JavaExec class.
- Dynamically attempt to continue calling the original property, but upon failure call the new property instead.

This addresses https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/602 and (somewhat) https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/611.