### PR TITLE
upgrade groovydsl to 2.0.2

### DIFF
--- a/module-versions.properties
+++ b/module-versions.properties
@@ -2,7 +2,7 @@
 
 # asciidoctorj-extension
 asciidoctorj=2.4.1
-asciidoctorj.groovydsl=2.0.0
+asciidoctorj.groovydsl=2.0.2
 asciidoctorj.diagram=2.0.5
 asciidoctorj.pdf=1.5.3
 asciidoctorj.epub=1.5.0-alpha.19


### PR DESCRIPTION
as groovydsl 2.0.0 was in jCenter now we are not able to use `docExtensions` 

