### PR TITLE
Add `@IgnoreEmptyDirectories` where adequate

### DIFF
--- a/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
+++ b/base/src/main/groovy/org/asciidoctor/gradle/base/AbstractAsciidoctorBaseTask.groovy
@@ -35,6 +35,7 @@ import org.gradle.api.file.FileTreeElement
 import org.gradle.api.provider.Provider
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Console
+import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
@@ -331,6 +332,7 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
      */
     @InputFiles
     @SkipWhenEmpty
+    @IgnoreEmptyDirectories
     @PathSensitive(RELATIVE)
     FileTree getSourceFileTree() {
         if (languages.empty) {
@@ -352,6 +354,7 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
      *
      */
     @InputFiles
+    @IgnoreEmptyDirectories
     @PathSensitive(RELATIVE)
     FileTree getSecondarySourceFileTree() {
         if (languages.empty) {
@@ -631,6 +634,7 @@ abstract class AbstractAsciidoctorBaseTask extends DefaultTask {
         super()
         inputs.files { filesFromCopySpec(getResourceCopySpec(Optional.empty())) }
             .withPathSensitivity(RELATIVE)
+            .ignoreEmptyDirectories()
         this.srcDir = createDirectoryProperty(project)
         this.outDir = createDirectoryProperty(project)
     }

--- a/jvm-pdf/src/main/groovy/org/asciidoctor/gradle/jvm/pdf/AsciidoctorPdfTask.groovy
+++ b/jvm-pdf/src/main/groovy/org/asciidoctor/gradle/jvm/pdf/AsciidoctorPdfTask.groovy
@@ -92,6 +92,7 @@ class AsciidoctorPdfTask extends AbstractAsciidoctorTask {
      * @return Directories for the pdf fonts
      * */
     @InputFiles
+    @IgnoreEmptyDirectories
     @PathSensitive(PathSensitivity.RELATIVE)
     @Optional
     FileCollection getFontsDirs() {


### PR DESCRIPTION
So SkipWhenEmpty keeps working as now with Gradle 8.0. See https://docs.gradle.org/current/userguide/upgrading_version_7.html#empty_directories_file_tree.