### PR TITLE
Support latest worker API methods for Gradle 8.0 compatibility

### DIFF
--- a/gradle/compatibility-tests.gradle
+++ b/gradle/compatibility-tests.gradle
@@ -5,23 +5,23 @@ pluginManager.withPlugin('org.ysb33r.cloudci') {
         travisci {
             gradleTest {
                 if (JavaVersion.current().java11) {
-                    versions '4.9', '6.7'
+                    versions '5.6.4', '7.5.1'
                 } else {
-                    versions '4.9', '6.0.1'
+                    versions '5.6.4', '6.0.1'
                 }
             }
         }
         appveyor {
             gradleTest {
-                versions '4.9', '5.0', '5.6.4', '6.0.1', '6.7'
+                versions '5.6.4', '6.0.1', '6.9.3'
             }
         }
         no_ci {
             gradleTest {
                 if (JavaVersion.current().java12) {
-                    versions '5.4.1', '6.0.1', '6.7'
+                    versions '5.6.4', '6.9.3', '7.5.1'
                 } else {
-                    versions '4.9', '5.0', '5.5.1', '6.0.1', '6.7'
+                    versions '5.6.4', '6.0.1', '6.9.3', '7.5.1'
                 }
             }
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskFunctionalSpec.groovy
+++ b/jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskFunctionalSpec.groovy
@@ -133,28 +133,32 @@ class AsciidoctorTaskFunctionalSpec extends FunctionalSpecification {
         noExceptionThrown()
     }
 
-    void 'Can run in JAVA_EXEC process mode (Groovy DSL)'() {
+    @Unroll
+    void "Can run in #processMode process mode (Groovy DSL)"() {
         given:
-        getBuildFile('''
+        getBuildFile("""
             asciidoctorj {
                 logLevel = 'INFO'
             }
 
             asciidoctor {
-                inProcess = JAVA_EXEC
+                inProcess = ${processMode}
 
                 outputOptions {
                     backends 'html5'
                 }
                 sourceDir 'src/docs/asciidoc'
             }
-        ''')
+        """)
 
         when:
         getGradleRunner(DEFAULT_ARGS).build()
 
         then:
         noExceptionThrown()
+
+        where:
+        processMode << ['IN_PROCESS', 'OUT_OF_PROCESS', 'JAVA_EXEC']
     }
 
     @Issue('https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/292')


### PR DESCRIPTION
Gradle 8.0 will retire the deprecated `WorkerExecutor.submit()` method.  This PR changes the plugin's use of the worker API to use the new methods introduced in Gradle 5.6.  This effectively raises the minimum supported Gradle version to 5.6 in order to use the the only worker API methods now supported in Gradle 8.0.  I've updated `compatibility-tests.gradle` to reflect this and test against newer versions, but I'm not entirely sure what the rationale was for the selection of versions that were in there previously.  If any of those look wrong, I'm happy to adjust.

There are some failing javascript integration tests, but it looks like those are failing on the main repository as well.  I don't think they are related to these changes.