### PR TITLE
Asciidoctor task is relocatable when `gemPaths` is configured

### DIFF
--- a/jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskCachingFunctionalSpec.groovy
+++ b/jvm/src/intTest/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskCachingFunctionalSpec.groovy
@@ -17,6 +17,7 @@ package org.asciidoctor.gradle.jvm
 
 import org.asciidoctor.gradle.internal.FunctionalSpecification
 import org.asciidoctor.gradle.testfixtures.CachingTest
+import spock.lang.Issue
 
 import static org.asciidoctor.gradle.testfixtures.AsciidoctorjTestVersions.SERIES_20
 import static org.asciidoctor.gradle.testfixtures.JRubyTestVersions.AJ20_ABSOLUTE_MINIMUM
@@ -24,6 +25,7 @@ import static org.asciidoctor.gradle.testfixtures.JRubyTestVersions.AJ20_SAFE_MA
 
 /** AsciidoctorTaskCachingFunctionalSpec
  *
+ * @author Eric Haag
  * @author Gary Hale
  */
 class AsciidoctorTaskCachingFunctionalSpec extends FunctionalSpecification implements CachingTest {
@@ -63,6 +65,37 @@ class AsciidoctorTaskCachingFunctionalSpec extends FunctionalSpecification imple
         file(DOCBOOK_OUTPUT_FILE).exists()
         outputFileInRelocatedDirectory.exists()
         fileInRelocatedDirectory(DOCBOOK_OUTPUT_FILE).exists()
+    }
+
+    @Issue('https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/671')
+    void "asciidoctor task is cacheable and relocatable when gemPaths is configured"() {
+        given:
+        getBuildFile("""
+            asciidoctorj {
+                gemPaths 'gems1', 'gems2'
+            }
+
+            asciidoctor {
+                sourceDir 'src/docs/asciidoc'
+                
+                outputOptions {
+                    backends 'html5', 'docbook'
+                }
+            }
+        """)
+
+        when:
+        assertDefaultTaskExecutes()
+
+        then:
+        outputFile.exists()
+
+        when:
+        assertDefaultTaskIsCachedAndRelocatable()
+
+        then:
+        outputFile.exists()
+        outputFileInRelocatedDirectory.exists()
     }
 
     void "Asciidoctor task is cached when only output directory is changed"() {

--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -321,6 +321,18 @@ class AbstractAsciidoctorTask extends AbstractAsciidoctorBaseTask {
         ([asciidoctorj.configuration] + asConfigurations(project, asciidocConfigurations)).toSet()
     }
 
+    /**
+     * Additional locations to consider when GEMs are loaded by AsciidoctorJ or JRuby.
+     *
+     * @return The additional GEM locations.
+     *
+     * @since 4.0
+     */
+    @Internal
+    String getGemPath() {
+        asciidoctorj.asGemPath()
+    }
+
     @SuppressWarnings('UnnecessaryGetter')
     @TaskAction
     void processAsciidocSources() {
@@ -356,9 +368,6 @@ class AbstractAsciidoctorTask extends AbstractAsciidoctorBaseTask {
         super()
         this.worker = we
         this.asciidoctorj = extensions.create(AsciidoctorJExtension.NAME, AsciidoctorJExtension, this)
-
-        addInputProperty 'gemPath', { AsciidoctorJExtension aj -> aj.asGemPath() }
-                .curry(this.asciidoctorj)
 
         addInputProperty 'required-ruby-modules', { AsciidoctorJExtension aj -> aj.requires }
                 .curry(this.asciidoctorj)
@@ -500,10 +509,6 @@ class AbstractAsciidoctorTask extends AbstractAsciidoctorBaseTask {
         } else {
             this.inProcess
         }
-    }
-
-    private String getGemPath() {
-        asciidoctorj.asGemPath()
     }
 
     private Map<String, ExecutorConfiguration> runWithWorkers(


### PR DESCRIPTION
This PR resolves a build cache miss that occurs when `gemPaths` is configured. The value of `gemPaths` may contain one or more absolute paths. This makes the task not relocatable and results in a build cache miss when executed from different directories with local build caching, or between two machines with remote build caching. 

To fix this, I marked `gemPath` with `@Internal` to exclude it from any sort of fingerprinting or cache key calculations. [Since the `gemPaths` are already being tracked as input files and are properly relativized](https://github.com/asciidoctor/asciidoctor-gradle-plugin/blob/996df6a028b69e3f7314ed61ca6af317776ace74/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy#L367C47-L368), there will be no regressions in terms of cacheability.

fixes #671