### PR TITLE
Fix a typo in javadoc

### DIFF
--- a/js/src/main/groovy/org/asciidoctor/gradle/js/base/AbstractAsciidoctorJSExtension.groovy
+++ b/js/src/main/groovy/org/asciidoctor/gradle/js/base/AbstractAsciidoctorJSExtension.groovy
@@ -115,7 +115,7 @@ abstract class AbstractAsciidoctorJSExtension extends AbstractImplementationEngi
      *
      * @param mod Module to interrogate
      *
-     * @return Module version or {@code null} if the componenet is not required.
+     * @return Module version or {@code null} if the component is not required.
      */
     protected String moduleVersion(final AsciidoctorModuleDefinition mod) {
         if (task) {


### PR DESCRIPTION
A very small and tiny single char typo fix