### PR TITLE
Fix Gradle 8 warning from AbstractAsciidoctorTask

### DIFF
--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -579,7 +579,7 @@ class AbstractAsciidoctorTask extends AbstractAsciidoctorBaseTask {
                 configureForkOptions(jes)
                 logger.debug "Running AsciidoctorJ instance with environment: ${jes.environment}"
                 jes.with {
-                    main = AsciidoctorJavaExec.canonicalName
+                    mainClass = AsciidoctorJavaExec.canonicalName
                     classpath = javaExecClasspath
                     args execConfigurationData.absolutePath
                 }


### PR DESCRIPTION
This change should fix the following warning seen with e.g. Gradle 8.5:

```
The JavaExecSpec.main property has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the mainClass property instead. For more information, please refer to https://docs.gradle.org/8.5/dsl/org.gradle.process.JavaExecSpec.html#org.gradle.process.JavaExecSpec:main in the Gradle documentation.
```

Seems like `mainClass` was added in Gradle 6.4:
- https://docs.gradle.org/6.4/javadoc/org/gradle/process/JavaExecSpec.html
- https://docs.gradle.org/6.3/javadoc/org/gradle/process/JavaExecSpec.html