### PR TITLE
Set Java Toolchain to enforce module JVM to 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,12 @@ subprojects {
             targetCompatibility = project.targetCompatibility
         }
 
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(8)
+            }
+        }
+
         project.tasks.withType(Test) {
             testLogging {
                 afterSuite { desc, result ->


### PR DESCRIPTION
Otherwise the value of 'org.gradle.jvm.version' is set to the JVM used during build.
