### PR TITLE
Use '\' to chain arguments in doc publication pipeline

### DIFF
--- a/.github/workflows/push-documentation.yml
+++ b/.github/workflows/push-documentation.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Publish documentation
         run: |
           cd docs
-          ./gradlew --console=plain --info :antora:publishDocs :gh-pages:publishDocs
-          -Dorg.ajoberstar.grgit.auth.username=${{ secrets.GITHUB_PUBLISH_USER }}
-          -Dorg.ajoberstar.grgit.auth.password=${{ secrets.GITHUB_PUBLISH_KEY }}
-          -Dorg.ajoberstar.grgit.auth.force=hardcoded
+          ./gradlew --console=plain --info :antora:publishDocs :gh-pages:publishDocs \
+            -Dorg.ajoberstar.grgit.auth.username=${{ secrets.GITHUB_PUBLISH_USER }} \
+            -Dorg.ajoberstar.grgit.auth.password=${{ secrets.GITHUB_PUBLISH_KEY }} \
+            -Dorg.ajoberstar.grgit.auth.force=hardcoded


### PR DESCRIPTION
Completing https://github.com/asciidoctor/asciidoctor-gradle-plugin/pull/708

From the error in [CI](https://github.com/asciidoctor/asciidoctor-gradle-plugin/actions/runs/7679511253/job/20930480087#step:6:607) we can infer the arguments are interpreted as independent statements.
```
/home/runner/work/_temp/f899399a-9ce7-4712-b5d6-6c9ed60e3894.sh: line 3: -Dorg.ajoberstar.grgit.auth.username=: command not found
```