### PR TITLE
Update compatibility-tests.gradle to 8.9

### DIFF
--- a/gradle/compatibility-tests.gradle
+++ b/gradle/compatibility-tests.gradle
@@ -4,7 +4,7 @@ pluginManager.withPlugin('org.ysb33r.cloudci') {
     ci {
         no_ci {
             gradleTest {
-                versions '7.0.2', '7.6.1', '8.5', '8.8'
+                versions '7.0.2', '7.6.1', '8.5', '8.9'
             }
         }
     }


### PR DESCRIPTION
Gradle 8.8 has a problem: https://github.com/spring-projects/spring-framework/pull/33213, so upgrade to 8.9