### PR TITLE
Do not use deprecated methods removed in Asciidoctor 3.x

### DIFF
--- a/jvm/src/main/groovy/org/asciidoctor/gradle/remote/AsciidoctorJSetup.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/remote/AsciidoctorJSetup.groovy
@@ -65,7 +65,7 @@ class AsciidoctorJSetup implements Serializable {
         runConfiguration.with {
             final String srcRelative = getRelativePath(file.parentFile, sourceDir)
 
-            options.each { key, value -> optionsBuilder.option(key, value.toString()) }
+            options.each { key, value -> optionsBuilder.option(key, value) }
             optionsBuilder.backend(backendName)
             optionsBuilder.inPlace(false)
             optionsBuilder.safe(SafeMode.safeMode(safeModeLevel))
@@ -82,7 +82,7 @@ class AsciidoctorJSetup implements Serializable {
             }
 
             AttributesBuilder attributesBuilder = Attributes.builder()
-            attributes.each { key, value -> attributesBuilder.attribute(key, value.toString()) }
+            attributes.each { key, value -> attributesBuilder.attribute(key, value) }
             attributesBuilder.attribute(ATTR_PROJECT_DIR, projectDir.absolutePath)
             attributesBuilder.attribute(ATTR_ROOT_DIR, rootDir.absolutePath)
             attributesBuilder.attribute(ATTR_REL_SRC_DIR, srcRelative.empty ? '.' : srcRelative)

--- a/jvm/src/main/groovy/org/asciidoctor/gradle/remote/ExecutorBase.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/remote/ExecutorBase.groovy
@@ -16,6 +16,7 @@
 package org.asciidoctor.gradle.remote
 
 import groovy.transform.CompileStatic
+import org.asciidoctor.Options
 import org.asciidoctor.ast.Cursor
 import org.asciidoctor.gradle.internal.ExecutorConfiguration
 import org.asciidoctor.gradle.internal.ExecutorConfigurationContainer
@@ -64,7 +65,7 @@ abstract class ExecutorBase {
      */
     @SuppressWarnings('DuplicateStringLiteral ')
     protected
-    Map<String, Object> normalisedOptionsFor(final File file, ExecutorConfiguration runConfiguration) {
+    Options normalisedOptionsFor(final File file, ExecutorConfiguration runConfiguration) {
         setup.normalisedOptionsFor(file, runConfiguration)
     }
 


### PR DESCRIPTION
This PR replaces the usage of the deprecated `convertFile` method used [here](https://github.com/asciidoctor/asciidoctor-gradle-plugin/blob/master/jvm/src/main/groovy/org/asciidoctor/gradle/remote/AsciidoctorJavaExec.groovy#L87).

This method is removed in Asciidoctor 3.x as mentioned [here](https://docs.asciidoctor.org/asciidoctorj/latest/guides/api-migration-guide-v25x-to-v30/#removal-of-methods-using-mapstringobject-as-options-input), which makes it impossible to use this plugin with Asciidoctor 3.x