### PR TITLE
Fix: Cache mismatch when absolute Path differ

### DIFF
--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -480,7 +480,11 @@ class AbstractAsciidoctorTask extends AbstractJvmModelExecTask<AsciidoctorJvmExe
         }.curry(project.configurations) as Function<List<Dependency>, Configuration>
 
         inputs.files(this.asciidoctorj.configuration)
-        inputs.files { gemJarProviders }.withPathSensitivity(RELATIVE)
+            .withPathSensitivity(RELATIVE)
+            .withPropertyName('asciidoctorj-dependencies')
+        inputs.files { gemJarProviders }
+            .withPathSensitivity(RELATIVE)
+            .withPropertyName('gemJarProviders')
         inputs.property 'backends', { -> backends() }
         inputs.property 'asciidoctorj-version', { -> asciidoctorj.version }
         inputs.property 'jruby-version', { -> asciidoctorj.jrubyVersion ?: '' }


### PR DESCRIPTION
Set a propertyName and pathSensitivity to RELATIVE for asciidoc-Task Inputs to fix a cache missmatch when the build happens on a different machine and the absolute path is different.