### PR TITLE
Avoid SelfResolvingDependency

### DIFF
--- a/js/src/main/groovy/org/asciidoctor/gradle/js/nodejs/AsciidoctorJSExtension.groovy
+++ b/js/src/main/groovy/org/asciidoctor/gradle/js/nodejs/AsciidoctorJSExtension.groovy
@@ -71,7 +71,8 @@ class AsciidoctorJSExtension extends AbstractAsciidoctorJSExtension {
         this.projectName = project.name
         this.nodejs = project.extensions.getByType(AsciidoctorJSNodeExtension)
         this.npm = project.extensions.getByType(AsciidoctorJSNpmExtension)
-        this.dependencyFactory = new NodeJSDependencyFactory(
+        this.dependencyFactory = project.objects.newInstance(
+                NodeJSDependencyFactory,
                 projectOperations,
                 this.nodejs,
                 this.npm
@@ -95,7 +96,8 @@ class AsciidoctorJSExtension extends AbstractAsciidoctorJSExtension {
         this.projectName = task.project.name
         this.nodejs = task.extensions.getByType(AsciidoctorJSNodeExtension)
         this.npm = task.extensions.getByType(AsciidoctorJSNpmExtension)
-        this.dependencyFactory = new NodeJSDependencyFactory(
+        this.dependencyFactory = task.project.objects.newInstance(
+                NodeJSDependencyFactory,
                 projectOperations,
                 this.nodejs,
                 this.npm

--- a/slides-export/src/main/groovy/org/asciidoctor/gradle/slides/export/decktape/DeckTapeExtension.groovy
+++ b/slides-export/src/main/groovy/org/asciidoctor/gradle/slides/export/decktape/DeckTapeExtension.groovy
@@ -24,7 +24,6 @@ import org.asciidoctor.gradle.js.nodejs.internal.PackageDescriptor
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
-import org.gradle.api.artifacts.SelfResolvingDependency
 import org.ysb33r.gradle.nodejs.NpmPackageDescriptor
 import org.ysb33r.gradle.nodejs.utils.npm.NpmExecutor
 import org.ysb33r.grolifant.api.core.ProjectOperations
@@ -65,14 +64,16 @@ class DeckTapeExtension {
         final NodeJSDependencyFactory factory = new NodeJSDependencyFactory(po, nodejs, npm)
         final NpmExecutor npmExecutor = new NpmExecutor(po, nodejs, npm)
 
+        final NpmPackageDescriptor pregypDescriptor = new SimpleNpmPackageDescriptor(PACKAGE_PREGYP.scope, PACKAGE_PREGYP.name, pregypVersion)
+
         // Ensure puppeteer is installed first
-        final List<SelfResolvingDependency> deps = [
+        final List<Dependency> deps = [
                 factory.createDependency(PACKAGE_PUPPETEER, puppeteerVersion),
-                factory.createDependency(PACKAGE_PREGYP, pregypVersion)
+                factory.createDependency(pregypDescriptor)
         ]
 
         File preGypBinPath = new File(
-                npmExecutor.getPackageInstallationFolder((NpmPackageDescriptor) deps[1]),
+                npmExecutor.getPackageInstallationFolder(pregypDescriptor),
                 'bin'
         )
 


### PR DESCRIPTION
SelfResolvingDependency has been deprecated in Gradle 8.x and will be removed in Gradle 9.0

BaseNpmSelfResolvingDependency implements this API, as well as Dependency, and SelfResolvingDependencyInternal.

Implementing Gradle interfaces like Dependency is asking for trouble, as these APIs are subject to change in Gradle major versions. Plus, implementing these APIs often require also implementing internal types.

`BaseNpmSelfResolvingDependency` will be impacted by multiple breaking changes in Gradle 9.0:
- https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_self_resolving_dependency
- https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_content_equals

This commit removes all references to SelfResolvingDependency, and all references to BaseNpmSelfResolvingDependency, which implements SelfResolvingDependency. Instead, it uses public Gradle APIs to create a FileCollectionDependency which lazily installs NPM dependencies.